### PR TITLE
Acquisition name update

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -14,7 +14,7 @@ def versions = [
 def archiveBaseName= 'sigmf-ns-ntia'
 
 group = 'gov.doc.ntia'
-version = '1.0.0'
+version = '1.0.1'
 
 sourceCompatibility = 1.8
 

--- a/java/src/main/java/gov/doc/ntia/sigmf/Acquisition.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/Acquisition.java
@@ -68,8 +68,11 @@ public class Acquisition implements Serializable {
    * @return the name for the acquisition.
    */
   public String getName() {
-    String name =
-        getMetaDoc().getGlobal().getSensor().getId() + "_" + getScheduleId() + "_" + getTaskId();
+
+    String sensorId = metaDoc.getGlobal().getSensor().getId();
+    String recording = metaDoc.getGlobal().getRecording().toString();
+    String name =sensorId
+         + "_" + getScheduleId() + "_" + getTaskId() + "_" + recording  ;
 
     return name;
   }

--- a/java/src/main/java/gov/doc/ntia/sigmf/Acquisition.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/Acquisition.java
@@ -70,9 +70,15 @@ public class Acquisition implements Serializable {
   public String getName() {
 
     String sensorId = metaDoc.getGlobal().getSensor().getId();
-    String recording = metaDoc.getGlobal().getRecording().toString();
-    String name =sensorId
-         + "_" + getScheduleId() + "_" + getTaskId() + "_" + recording  ;
+    Integer recording = metaDoc.getGlobal().getRecording();
+    String taskId = getTaskId();
+    String name = sensorId + "_" + getScheduleId();
+    if(taskId != null){
+      name += "_" + taskId;
+    }
+    if(recording != null){
+      name += "_" + recording;
+    }
 
     return name;
   }


### PR DESCRIPTION
Adds recording to the acquisition name and only appends task and recording to the name if they are not null. 