### PR TITLE
Add ProbabilityDistributionAnnotation Segment

### DIFF
--- a/ntia-algorithm.sigmf-ext.md
+++ b/ntia-algorithm.sigmf-ext.md
@@ -604,5 +604,29 @@ number of samples in the annotated data from a larger set of gap-free IQ samples
 ### 4.6 ProbabilityDistributionAnnotation Example
 
 ```json
-TODO
+{
+  "global": {
+    ...
+  },
+  "captures": [
+    ...
+  ],
+  "annotations": [
+    {
+      "ntia-core:annotation_type": "ProbabilityDistributionAnnotation",
+      "core:sample_start": 0,
+      "core:sample_count": 1000,
+      "ntia-algorithm:function": "amplitude_probability_distribution",
+      "ntia-algorithm:units": "dBm",
+      "ntia-algorithm:probability_units": "dimensionless",
+      "ntia-algorithm:number_of_samples": 56000000,
+      "ntia-algorithm:reference": "antenna terminal",
+      "ntia-algorithm:probabilities":
+          [0.9999999, 0.999999, 0.9999, 0.999, 0.9, 0.8, ... 0.01, 0.001, 0.0001],
+      "ntia-algorithm:downsampled": true,
+      "ntia-algorithm:downsampling_method":
+          "Distribution binned by amplitude with a resolution/bin size of 0.5 dB",
+    }
+  ]
+}
 ```

--- a/ntia-algorithm.sigmf-ext.md
+++ b/ntia-algorithm.sigmf-ext.md
@@ -77,6 +77,29 @@ The `FrequencyDomainDetection` has the following properties:
 |`attenuation_stopband`|false|double|dB|Attenuation of stopband.|
 |`frequency_stopband`|false|double|Hz|Point in filter frequency response where stopband starts.|
 
+### 3.4 ProbabilityDistributionAnnotation Segment
+
+Probability distributions of various types can be generated from gap-free IQ series. The
+`ProbabilityDistributionAnnotation` describes the type of distribution and specifies the
+probability values which correspond to the annotated data. The specification also supports
+human-readable descriptions of downsampling methods which may be applied to reduce the
+number of samples in the annotated data from a larger set of gap-free IQ samples.
+`ProbabilityDistributionAnnotation` has the following properties:
+
+|name|required|type|unit|description|
+|----|--------|----|----|-----------|
+|`function`|true|string|N/A|The estimated probability distribution function, e.g., `"cumulative_distribution"`, `"probability_density"`, `"amplitude_probability_distribution"`|
+|`units`|true|string|N/A|Data units, e.g., `"dBm"`, `"volts"`, `"watts"`.|
+|`probability_units`|true|string|N/A|The unit of the probability values, generally either `"dimensionless"` or `"percent"`.|
+|`number_of_samples`|false|integer|N/A|Number of samples used to estimate the probability distribution function. In the case of a downsampled result, this number may be larger than the length of the data.|
+|`reference`|false|string|N/A|Data reference point, e.g., `"signal analyzer input"`, `"preselector input"`, `"antenna terminal"`.|
+|`probability_start`|false|double|`probability_units`|Probability of the first data point.|
+|`probability_stop`|false|double|`probability_units`|Probability of the last data point.|
+|`probability_step`|false|double|`probability_units`|Step size between data points. This should **only** be used if the probability step size is constant between all data points.|
+|`probabilities`|false|double[]|`probability_units`|An array of the probabilities for all data points. This **must** be used if the probability step size is not constant (i.e. if the probability axis cannot be specified fully using `probability_start`, `probability_stop`, and `probability_step`.|
+|`downsampled`|false|boolean|N/A|Whether or not the probability distribution data has been downsampled|
+|`downsampling_method`|false|string|N/A|The method used for downsampling, e.g "Uniform downsampling by a factor of 2" or "Distribution binned by amplitude with a resolution of 0.5 dB"|
+
 ## 4 Example
 
 ### 4.1 anti_aliasing_filter example
@@ -576,4 +599,10 @@ The `FrequencyDomainDetection` has the following properties:
     }
   ]
 }
+```
+
+### 4.6 ProbabilityDistributionAnnotation Example
+
+```json
+TODO
 ```

--- a/ntia-core.sigmf-ext.md
+++ b/ntia-core.sigmf-ext.md
@@ -70,7 +70,7 @@ The Measurement object summarizes the basic measurement information including  w
 
 |name|required|type|unit|description|
 |----|--------------|-------|-------|-----------|
-|`annotation_type`|true|string|N/A|Annotation type, e.g. [`"CalibrationAnnotation"`](ntia-sensor.sigmf-ext.md#32-calibrationannotation-segment), [`"DigitalFilterAnnotation"`](ntia-algorithm.sigmf-ext.md#33-digitalfilterannotation-segment), [`"FrequencyDomainDetection"`](ntia-algorithm.sigmf-ext.md#32-frequencydomaindetection-segment), [`"SensorAnnotation"`](ntia-sensor.sigmf-ext.md#31-sensorannotation-segment), [`"TimeDomainDetection"`](ntia-algorithm.sigmf-ext.md#31-timedomaindetection-segment)|
+|`annotation_type`|true|string|N/A|Annotation type, e.g. [`"CalibrationAnnotation"`](ntia-sensor.sigmf-ext.md#32-calibrationannotation-segment), [`"DigitalFilterAnnotation"`](ntia-algorithm.sigmf-ext.md#33-digitalfilterannotation-segment), [`"FrequencyDomainDetection"`](ntia-algorithm.sigmf-ext.md#32-frequencydomaindetection-segment), [`"SensorAnnotation"`](ntia-sensor.sigmf-ext.md#31-sensorannotation-segment), [`"TimeDomainDetection"`](ntia-algorithm.sigmf-ext.md#31-timedomaindetection-segment), [`"ProbabilityDistributionAnnotation"`](ntia-algorithm.sigmf-ext.md#34-probabilitydistributionannotation-segment)|
 
 
 ## 4 Examples


### PR DESCRIPTION
Addresses #31. This is only an update to the README spec files for now; no Java changes are included.

- Adds the `ProbabilityDistributionAnnotation` segment to `ntia-algorithm`.

Version numbers are not changed in this PR, since this PR will likely be combined with others and version numbers should then be incremented as needed. This PR is a fully backwards-compatible feature addition.