### PR TITLE
`ntia-diagnostics` v1.1.0 and `ntia-nasctn-sea` v0.6.0

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -14,7 +14,7 @@ def versions = [
 def archiveBaseName= 'sigmf-ns-ntia'
 
 group = 'gov.doc.ntia'
-version = '2.0.1'
+version = '2.0.2'
 
 sourceCompatibility = 1.8
 

--- a/java/src/main/java/gov/doc/ntia/sigmf/Global.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/Global.java
@@ -149,6 +149,11 @@ public class Global implements Serializable {
   @JsonProperty(value = "ntia-nasctn-sea:max_of_max_channel_powers")
   protected List<Double> maxOfMaxChannelPowers;
 
+  @JsonProperty(value = "ntia-nasctn-sea:mean_channel_powers")
+  protected List<Double> meanChannelPowers;
+
+  @JsonProperty(value = "ntia-nasctn-sea:median_channel_powers")
+  protected List<Double> medianChannelPowers;
   @JsonProperty(value = "ntia-nasctn-sea:median_of_mean_channel_powers")
   protected List<Double> medianOfMeanChannelPowers;
 
@@ -420,6 +425,16 @@ public class Global implements Serializable {
 
   public void setMaxOfMaxChannelPowers(List<Double> maxOfMaxChannelPowers) {
     this.maxOfMaxChannelPowers = maxOfMaxChannelPowers;
+  }
+
+  public List<Double> getMeanChannelPowers() { return meanChannelPowers; }
+
+  public void setMeanChannelPowers(List<Double> meanChannelPowers) { this.meanChannelPowers = meanChannelPowers; }
+
+  public List<Double> getMedianChannelPowers() { return medianChannelPowers; }
+
+  public void setMedianChannelPowers(List<Double> medianChannelPowers) {
+    this.medianChannelPowers = medianChannelPowers;
   }
 
   public List<Double> getMedianOfMeanChannelPowers() {

--- a/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
@@ -8,6 +8,7 @@ import gov.doc.ntia.sigmf.examples.ExampleUtils;
 import gov.doc.ntia.sigmf.ext.diagnostics.Computer;
 import gov.doc.ntia.sigmf.ext.diagnostics.Diagnostics;
 import gov.doc.ntia.sigmf.ext.diagnostics.Preselector;
+import gov.doc.ntia.sigmf.ext.diagnostics.Software;
 import gov.doc.ntia.sigmf.ext.diagnostics.SPU;
 import gov.doc.ntia.sigmf.ext.diagnostics.SsdSmartData;
 
@@ -16,7 +17,7 @@ public class DiagnosticsExample implements Example {
   public static Extension getExtension() {
     Extension extension = new Extension();
     extension.setName("ntia-diagnostics");
-    extension.setVersion("v1.0.0");
+    extension.setVersion("v1.1.0");
     extension.setOptional(false);
     return extension;
   }
@@ -27,6 +28,9 @@ public class DiagnosticsExample implements Example {
 
     Preselector preselector = getPreselectorDiagnostics();
     diagnostics.setPreselector(preselector);
+
+    Software software = getSoftwareDiagnostics();
+    diagnostics.setSoftware(software);
 
     SPU spu = getSPUDiagnostics();
     diagnostics.setSpu(spu);
@@ -47,6 +51,16 @@ public class DiagnosticsExample implements Example {
     preselector.setHumidity(65.0);
     preselector.setDoorClosed(true);
     return preselector;
+  }
+
+  public static Software getSoftwareDiagnostics() {
+    Software software = new Software();
+    software.setSystemPlatform("Linux-9.9.9-example-platform");
+    software.setPythonVersion("3.11.5");
+    software.setScosSensorVersion("1.0.0-gcbb75ad");
+    software.setScosActionsVersion("2.0.0");
+    software.setPreselectorApiVersion("1.0.0");
+    return software;
   }
 
   public static SPU getSPUDiagnostics() {

--- a/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/NasctnSeaExample.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/NasctnSeaExample.java
@@ -13,7 +13,7 @@ public class NasctnSeaExample implements Example {
     public static Extension getExtension() {
         Extension extension = new Extension();
         extension.setName("ntia-nasctn-sea");
-        extension.setVersion("v0.5.0");
+        extension.setVersion("v0.6.0");
         extension.setOptional(false);
         return extension;
     }
@@ -29,14 +29,24 @@ public class NasctnSeaExample implements Example {
         maxOfMax.add(-89.0);
         maxOfMax.add(-93.0);
         maxOfMax.add(-95.0);
-        maxOfMax.add(-87.0);
         global.setMaxOfMaxChannelPowers(maxOfMax);
+
+        ArrayList<Double> mean = new ArrayList<>();
+        mean.add(-98.0);
+        mean.add(-102.0);
+        mean.add(-104.0);
+        global.setMeanChannelPowers(mean);
+
+        ArrayList<Double> median = new ArrayList<>();
+        median.add(-98.5);
+        median.add(-102.5);
+        median.add(-104.5);
+        global.setMedianChannelPowers(median);
 
         ArrayList<Double> medianOfMean = new ArrayList<>();
         medianOfMean.add(-99.0);
         medianOfMean.add(-103.0);
         medianOfMean.add(-105.0);
-        medianOfMean.add(-97.0);
         global.setMedianOfMeanChannelPowers(medianOfMean);
         
         metaDoc.setGlobal(global);

--- a/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Diagnostics.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Diagnostics.java
@@ -19,6 +19,9 @@ public class Diagnostics {
   private Preselector preselector;
 
   @Valid
+  private Software software;
+
+  @Valid
   private SPU spu;
 
   @JsonProperty(value = "action_runtime")
@@ -39,6 +42,10 @@ public class Diagnostics {
   public void setPreselector(Preselector preselector) {
     this.preselector = preselector;
   }
+
+  public Software getSoftware() { return software; }
+
+  public void setSoftware(Software software) { this.software = software; }
 
   public SPU getSpu() {
     return spu;

--- a/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Software.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Software.java
@@ -1,0 +1,63 @@
+package gov.doc.ntia.sigmf.ext.diagnostics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Software {
+
+    @JsonProperty(value = "system_platform")
+    protected String systemPlatform;
+
+    @JsonProperty(value = "python_version")
+    protected String pythonVersion;
+
+    @JsonProperty(value = "scos_sensor_version")
+    protected String scosSensorVersion;
+
+    @JsonProperty(value = "scos_actions_version")
+    protected String scosActionsVersion;
+
+    @JsonProperty(value = "preselector_api_version")
+    protected String preselectorApiVersion;
+
+    public String getSystemPlatform() {
+        return systemPlatform;
+    }
+
+    public void setSystemPlatform(String systemPlatform) {
+        this.systemPlatform = systemPlatform;
+    }
+
+    public String getPythonVersion() {
+        return pythonVersion;
+    }
+
+    public void setPythonVersion(String pythonVersion) {
+        this.pythonVersion = pythonVersion;
+    }
+
+    public String getScosSensorVersion() {
+        return scosSensorVersion;
+    }
+
+    public void setScosSensorVersion(String scosSensorVersion) {
+        this.scosSensorVersion = scosSensorVersion;
+    }
+
+    public String getScosActionsVersion() {
+        return scosActionsVersion;
+    }
+
+    public void setScosActionsVersion(String scosActionsVersion) {
+        this.scosActionsVersion = scosActionsVersion;
+    }
+
+    public String getPreselectorApiVersion() {
+        return preselectorApiVersion;
+    }
+
+    public void setPreselectorApiVersion(String preselectorApiVersion) {
+        this.preselectorApiVersion = preselectorApiVersion;
+    }
+}

--- a/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
+++ b/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
@@ -8,6 +8,7 @@ import gov.doc.ntia.sigmf.ext.algorithm.AbstractProcessing;
 import gov.doc.ntia.sigmf.ext.algorithm.DFT;
 import gov.doc.ntia.sigmf.ext.algorithm.Graph;
 import gov.doc.ntia.sigmf.ext.diagnostics.Computer;
+import gov.doc.ntia.sigmf.ext.diagnostics.Software;
 import gov.doc.ntia.sigmf.ext.sensor.Calibration;
 import java.io.File;
 import java.io.IOException;
@@ -238,6 +239,16 @@ public class NasctnSensorTest {
   }
 
   @Test
+  public void testDeserializeDiagnosticsSoftware(){
+    Software software = metaDoc.getGlobal().getDiagnostics().getSoftware();
+    Assertions.assertEquals("Linux-5.4.0-153-generic-x86_64-with-glibc2.29", software.getSystemPlatform());
+    Assertions.assertEquals("3.8.10", software.getPythonVersion());
+    Assertions.assertEquals("6.3.3",software.getScosActionsVersion());
+    Assertions.assertEquals( "3.0.2", software.getPreselectorApiVersion());
+    Assertions.assertEquals("1.0.0-gcbb75ad", software.getScosSensorVersion());
+  }
+
+  @Test
   public void testDeserializeMaxOfMaxChannelPowers() {
     List<Double> maxPowers = metaDoc.getGlobal().getMaxOfMaxChannelPowers();
     Assertions.assertEquals(15, maxPowers.size());
@@ -251,6 +262,22 @@ public class NasctnSensorTest {
     Assertions.assertEquals(15, medianOfMeanPowers.size());
     Assertions.assertEquals(-83.875, medianOfMeanPowers.get(0).doubleValue());
     Assertions.assertEquals(-85.8125, medianOfMeanPowers.get(14).doubleValue());
+  }
+
+  @Test
+  public void testDeserializeMeanChannelPowers() {
+    List<Double> meanChannelPowers = metaDoc.getGlobal().getMeanChannelPowers();
+    Assertions.assertEquals(15, meanChannelPowers.size());
+    Assertions.assertEquals( -76.0, meanChannelPowers.get(0).doubleValue());
+    Assertions.assertEquals(-75.1875, meanChannelPowers.get(14).doubleValue());
+  }
+
+  @Test
+  public void testDeserializeMedianChannelPowers() {
+    List<Double> medianChannelPowers = metaDoc.getGlobal().getMedianChannelPowers();
+    Assertions.assertEquals(15, medianChannelPowers.size());
+    Assertions.assertEquals( -83.3125, medianChannelPowers.get(0).doubleValue());
+    Assertions.assertEquals(-95.9375, medianChannelPowers.get(14).doubleValue());
   }
 
   @Test

--- a/java/src/test/resources/meta.sigmf-meta
+++ b/java/src/test/resources/meta.sigmf-meta
@@ -176,6 +176,40 @@
       -92.0625,
       -85.8125
     ],
+    "ntia-nasctn-sea:mean_channel_powers": [
+      -76.0,
+      -75.625,
+      -76.375,
+      -79.5625,
+      -77.875,
+      -75.0,
+      -86.8125,
+      -85.6875,
+      -83.6875,
+      -88.0,
+      -87.875,
+      -86.5625,
+      -92.875,
+      -90.75,
+      -75.1875
+    ],
+    "ntia-nasctn-sea:median_channel_powers": [
+      -83.3125,
+      -81.3125,
+      -81.5,
+      -83.0,
+      -83.5,
+      -81.5,
+      -91.8125,
+      -89.375,
+      -90.75,
+      -92.125,
+      -96.0625,
+      -95.875,
+      -96.625,
+      -95.125,
+      -95.9375
+    ],
     "ntia-diagnostics:diagnostics": {
       "datetime": "2023-04-06T21:31:39.356Z",
       "preselector": {
@@ -213,6 +247,13 @@
           "unsafe_shutdowns": 18,
           "integrity_errors": 0
         }
+      },
+      "software": {
+        "system_platform": "Linux-5.4.0-153-generic-x86_64-with-glibc2.29",
+        "python_version": "3.8.10",
+        "scos_actions_version": "6.3.3",
+        "preselector_api_version": "3.0.2",
+        "scos_sensor_version": "1.0.0-gcbb75ad"
       },
       "action_runtime": 81.8970819178503
     }

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -1,4 +1,4 @@
-# The `ntia-diagnostics` SigMF Extension Namespace v1.0.0
+# The `ntia-diagnostics` SigMF Extension Namespace v1.1.0
 
 This document defines the `ntia-diagnostics` extension namespace for the Signal Metadata Format (SigMF) specification. This extension namespace provides metadata to describe system diagnostic information.
 
@@ -12,6 +12,7 @@ The `ntia-diagnostics` extension defines the following datatypes:
 |`Preselector`|preselector diagnostics|JSON [Preselector](#02-the-preselector-diagnostics-object) object containing diagnostics for a preselector|
 |`SPU`|signal processing unit diagnostics|JSON [SPU](#03-the-spu-diagnostics-object) object containing diagnostics for a signal processing unit|
 |`Computer`|computer diagnostics|JSON [Computer](#04-the-computer-diagnostics-object) object containing diagnostics for a computer which runs SCOS|
+|`Software`|software versions|JSON [Software](#06-the-software-versions-object) object containing software version information|
 |`SsdSmartData`|solid-state drive SMART diagnostics|JSON [SsdSmartData](#05-the-ssdsmartdata-diagnostics-object) object containing results of SMART diagnostics for an SSD|
 
 Multiple key/value pairs in the objects defined by this extension MUST be ISO-8601 strings, as defined by [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt), where the only allowed `time-offset` is `z`, indicating the UTC/Zulu timezone. Thus, timestamps take the form of `YYYY-MM-DDTHH:MM:SS.SSSZ`, where any number of digits for fractional seconds is permitted.
@@ -26,6 +27,7 @@ Multiple key/value pairs in the objects defined by this extension MUST be ISO-86
 | `preselector`    |false| [Preselector](#02-the-preselector-diagnostics-object) | N/A     | Metadata to capture preselector diagnostics.                                        |
 | `spu`            |false| [SPU](#03-the-spu-diagnostics-object)                 | N/A     | Metadata to capture signal processing unit diagnostics.                             |
 | `computer`       |false| [Computer](#04-the-computer-diagnostics-object)       | N/A     | Metadata to capture computer diagnostics.                                           |
+| `software`       |false| [Software](#06-the-software-versions-object)          | N/A     | Metadata to capture software versions.                                              |
 | `action_runtime` |false| double                                                | seconds | Total action execution time.                                                        |
 
 ### 0.2 The `Preselector` Diagnostics Object
@@ -87,6 +89,18 @@ The `SsdSmartData` diagnostics object has the following properties:
 | `percentage_used`           |false| double  | percent        | Contains a vendor specific estimate of the percentage of NVM subsystem life used based on the actual usage and the manufacturer’s prediction of NVM life. A value of 100 indicates that the estimated endurance of the NVM in the NVM subsystem has been consumed, but may not indicate an NVM subsystem failure. Values may exceed 100 and percentages greater than 254 shall be represented as 255. |
 | `unsafe_shutdowns`          |false| int     | N/A            | Number of unsafe shutdowns.                                                                                                                                                                                                                                                                                                                                                                           |
 | `integrity_errors`          |false| int     | N/A            | Number of occurrences where the controller detected an unrecovered data integrity error                  |
+
+### 0.6 The Software Versions Object
+
+The `Software` versions object has the following properties:
+
+| name                      | required | type   | description                                                                                                                                          |
+|---------------------------|----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `system_platform`         | false    | string | A human-readable representation of the generator's software platform, e.g. "Linux-5.4.0-153-generic-x86_64-with-glibc2.29"                           |
+| `python_version`          | false    | string | [SemVer](https://semver.org/) representation of the Python version used by the generator                                                             |
+| `scos_sensor_version`     | false    | string | The [SCOS Sensor](https://github.com/NTIA/scos-sensor) version of the generator, in the form output by `git describe --tags`, e.g., "1.0.0-gebbc956" |
+| `scos_actions_version`    | false    | string | [SemVer](https://semver.org/) representation of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin version used by the generator        |
+| `preselector_api_version` | false    | string | [SemVer](https://semver.org/) representation of the [ITS Preselector API](https://github.com/NTIA/Preselector) version used by the generator         |
 
 ## 1 Global
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -94,13 +94,13 @@ The `SsdSmartData` diagnostics object has the following properties:
 
 The `Software` versions object has the following properties:
 
-| name                      | required | type   | description                                                                                                                                          |
-|---------------------------|----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `system_platform`         | false    | string | A human-readable representation of the generator's software platform, e.g. "Linux-5.4.0-153-generic-x86_64-with-glibc2.29"                           |
-| `python_version`          | false    | string | [SemVer](https://semver.org/) representation of the Python version used by the generator                                                             |
+| name                      | required | type   | description                                                                                                                                         |
+|---------------------------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `system_platform`         | false    | string | A human-readable representation of the generator's software platform, e.g. "Linux-5.4.0-153-generic-x86_64-with-glibc2.29"                          |
+| `python_version`          | false    | string | [SemVer](https://semver.org/) representation of the Python version used by the generator                                                            |
 | `scos_sensor_version`     | false    | string | The [SCOS Sensor](https://github.com/NTIA/scos-sensor) version of the generator, in the form output by `git describe --tags`, e.g., "1.0.0-gebbc956" |
-| `scos_actions_version`    | false    | string | [SemVer](https://semver.org/) representation of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin version used by the generator        |
-| `preselector_api_version` | false    | string | [SemVer](https://semver.org/) representation of the [ITS Preselector API](https://github.com/NTIA/Preselector) version used by the generator         |
+| `scos_actions_version`    | false    | string | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator             |
+| `preselector_api_version` | false    | string | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator |
 
 ## 1 Global
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -94,13 +94,13 @@ The `SsdSmartData` diagnostics object has the following properties:
 
 The `Software` versions object has the following properties:
 
-| name                      | required | type   | description                                                                                                                                         |
-|---------------------------|----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `system_platform`         | false    | string | A human-readable representation of the generator's software platform, e.g. "Linux-5.4.0-153-generic-x86_64-with-glibc2.29"                          |
-| `python_version`          | false    | string | [SemVer](https://semver.org/) representation of the Python version used by the generator                                                            |
+| name                      | required | type   | description                                                                                                                                          |
+|---------------------------|----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `system_platform`         | false    | string | A human-readable representation of the generator's software platform, e.g. "Linux-5.4.0-153-generic-x86_64-with-glibc2.29"                           |
+| `python_version`          | false    | string | [Semantic version](https://semver.org/) of Python used by the generator                                                                              |
 | `scos_sensor_version`     | false    | string | The [SCOS Sensor](https://github.com/NTIA/scos-sensor) version of the generator, in the form output by `git describe --tags`, e.g., "1.0.0-gebbc956" |
-| `scos_actions_version`    | false    | string | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator             |
-| `preselector_api_version` | false    | string | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator |
+| `scos_actions_version`    | false    | string | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator                     |
+| `preselector_api_version` | false    | string | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator                      |
 
 ## 1 Global
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -137,10 +137,10 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
       "optional" : false
     }, {
       "name" : "ntia-diagnostics",
-      "version" : "v1.0.0",
+      "version" : "v1.1.0",
       "optional" : false
     } ],
-    "ntia-core:classification": "UNCLASSIFIED",
+    "ntia-core:classification" : "UNCLASSIFIED",
     "ntia-diagnostics:diagnostics" : {
       "computer" : {
         "cpu_max_clock" : 4800.0,
@@ -153,7 +153,7 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
         "cpu_overheating" : false,
         "cpu_uptime" : 10.0,
         "scos_uptime" : 1.0,
-        "scos_start_time" : "2023-05-31T19:39:34.399Z",
+        "scos_start" : "2023-09-09T10:17:29.726Z",
         "ssd_smart_data" : {
           "temp" : 41.0,
           "test_passed" : true,
@@ -165,13 +165,20 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
           "integrity_errors" : 0
         }
       },
-      "datetime" : "2023-05-31T19:39:34.378Z",
+      "datetime" : "2023-09-09T10:17:29.722Z",
       "preselector" : {
         "temp" : 21.6,
         "humidity" : 65.0,
         "noise_diode_temp" : 21.8,
         "lna_temp" : 21.8,
         "door_closed" : true
+      },
+      "software" : {
+        "system_platform" : "Linux-9.9.9-example-platform",
+        "python_version" : "3.11.5",
+        "scos_sensor_version" : "1.0.0-gcbb75ad",
+        "scos_actions_version" : "2.0.0",
+        "preselector_api_version" : "1.0.0"
       },
       "spu" : {
         "rf_tray_powered" : true,

--- a/ntia-nasctn-sea.sigmf-ext.md
+++ b/ntia-nasctn-sea.sigmf-ext.md
@@ -1,4 +1,4 @@
-# The `ntia-nasctn-sea` SigMF Extension Namespace v0.5.0
+# The `ntia-nasctn-sea` SigMF Extension Namespace v0.6.0
 
 This document defines the `ntia-nasctn-sea` extension namespace for the Signal Metadata Format (SigMF) specification. This namespace extension provides metadata objects specifically suited for the NASCTN Sharing Ecosystem Assessment (SEA) project.
 
@@ -8,11 +8,13 @@ The `ntia-nasctn-sea` extension does not define any additional datatypes.
 
 ## 1 Global
 
-The `ntia-nasctn-sea` extension adds the following fields to the `global` SigMF object:
+The `ntia-nasctn-sea` extension adds the following fields, which provide summary power statistics for each capture in a recording, to the `global` SigMF object:
 
 | name                            | required | type     | unit | description                                   |
 |---------------------------------|----------|----------|------|-----------------------------------------------|
 | `max_of_max_channel_powers`     | false    | double[] | dBm  | The maximum of the maximum power per channel. |
+| `mean_channel_powers`           | false    | double[] | dBm  | The mean power per channel.                   |
+| `median_channel_powers`         | false    | double[] | dBm  | The median power per channel.                 |
 | `median_of_mean_channel_powers` | false    | double[] | dBm  | The median of the mean power per channel.     |
 
 ## 2 Captures

--- a/ntia-nasctn-sea.sigmf-ext.md
+++ b/ntia-nasctn-sea.sigmf-ext.md
@@ -46,12 +46,14 @@ The example shown below uses this extension to record channel power summaries fo
       "optional" : false
     }, {
       "name" : "ntia-nasctn-sea",
-      "version" : "v0.5.0",
+      "version" : "v0.6.0",
       "optional" : false
     } ],
     "ntia-core:classification" : "UNCLASSIFIED",
-    "ntia-nasctn-sea:max_of_max_channel_powers" : [ -89.0, -93.0, -95.0, -87.0 ],
-    "ntia-nasctn-sea:median_of_mean_channel_powers" : [ -99.0, -103.0, -105.0, -97.0 ]
+    "ntia-nasctn-sea:max_of_max_channel_powers" : [ -89.0, -93.0, -95.0 ],
+    "ntia-nasctn-sea:mean_channel_powers" : [ -98.0, -102.0, -104.0 ],
+    "ntia-nasctn-sea:median_channel_powers" : [ -98.5, -102.5, -104.5 ],
+    "ntia-nasctn-sea:median_of_mean_channel_powers" : [ -99.0, -103.0, -105.0 ]
   },
   ...
   "captures" : [ ... ],


### PR DESCRIPTION
This PR makes changes to `ntia-diagnostics` and `ntia-nasctn-sea` extensions based on NTIA/scos-actions#88

This adds a new diagnostics object for recording various software versions, and two new channel power summary objects for NASCTN SEA.

The markdown specs, Java classes, and JSON example generators are all updated.