### PR TITLE
`ntia-diagnostics` v1.1.1

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -14,7 +14,7 @@ def versions = [
 def archiveBaseName= 'sigmf-ns-ntia'
 
 group = 'gov.doc.ntia'
-version = '2.0.2'
+version = '2.0.3'
 
 sourceCompatibility = 1.8
 

--- a/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
@@ -17,7 +17,7 @@ public class DiagnosticsExample implements Example {
   public static Extension getExtension() {
     Extension extension = new Extension();
     extension.setName("ntia-diagnostics");
-    extension.setVersion("v1.1.0");
+    extension.setVersion("v1.1.1");
     extension.setOptional(false);
     return extension;
   }
@@ -59,6 +59,7 @@ public class DiagnosticsExample implements Example {
     software.setPythonVersion("3.11.5");
     software.setScosSensorVersion("1.0.0-gcbb75ad");
     software.setScosActionsVersion("2.0.0");
+    software.setScosTekrsaVersion("3.1.3");
     software.setPreselectorApiVersion("1.0.0");
     return software;
   }

--- a/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Software.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Software.java
@@ -18,6 +18,9 @@ public class Software {
     @JsonProperty(value = "scos_actions_version")
     protected String scosActionsVersion;
 
+    @JsonProperty(value = "scos_tekrsa_version")
+    protected String scosTekrsaVersion;
+
     @JsonProperty(value = "preselector_api_version")
     protected String preselectorApiVersion;
 
@@ -52,6 +55,10 @@ public class Software {
     public void setScosActionsVersion(String scosActionsVersion) {
         this.scosActionsVersion = scosActionsVersion;
     }
+
+    public String getScosTekrsaVersion() { return scosTekrsaVersion; }
+
+    public void setScosTekrsaVersion(String scosTekrsaVersion) { this.scosTekrsaVersion = scosTekrsaVersion; }
 
     public String getPreselectorApiVersion() {
         return preselectorApiVersion;

--- a/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
+++ b/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
@@ -243,7 +243,8 @@ public class NasctnSensorTest {
     Software software = metaDoc.getGlobal().getDiagnostics().getSoftware();
     Assertions.assertEquals("Linux-5.4.0-153-generic-x86_64-with-glibc2.29", software.getSystemPlatform());
     Assertions.assertEquals("3.8.10", software.getPythonVersion());
-    Assertions.assertEquals("6.3.3",software.getScosActionsVersion());
+    Assertions.assertEquals("6.3.3", software.getScosActionsVersion());
+    Assertions.assertEquals("3.1.3", software.getScosTekrsaVersion());
     Assertions.assertEquals( "3.0.2", software.getPreselectorApiVersion());
     Assertions.assertEquals("1.0.0-gcbb75ad", software.getScosSensorVersion());
   }

--- a/java/src/test/resources/meta.sigmf-meta
+++ b/java/src/test/resources/meta.sigmf-meta
@@ -13,6 +13,11 @@
         "optional": false
       },
       {
+        "name": "ntia-diagnostics",
+        "version": "v1.1.1",
+        "optional": true
+      },
+      {
         "name": "ntia-environment",
         "version": "v1.0.0",
         "optional": false
@@ -24,7 +29,7 @@
       },
       {
         "name": "ntia-nasctn-sea",
-        "version": "v0.5.0",
+        "version": "v0.6.0",
         "optional": false
       }
     ],
@@ -252,6 +257,7 @@
         "system_platform": "Linux-5.4.0-153-generic-x86_64-with-glibc2.29",
         "python_version": "3.8.10",
         "scos_actions_version": "6.3.3",
+        "scos_tekrsa_version": "3.1.3",
         "preselector_api_version": "3.0.2",
         "scos_sensor_version": "1.0.0-gcbb75ad"
       },

--- a/java/src/test/resources/sigmf-ns-ntia.schema
+++ b/java/src/test/resources/sigmf-ns-ntia.schema
@@ -116,6 +116,18 @@
 						"type": "number"
 					}
 				},
+				"ntia-nasctn-sea:mean_channel_powers": {
+				    "type": "array",
+				    "items": {
+				        "type": "number"
+				    }
+				},
+				"ntia-nasctn-sea:median_channel_powers": {
+				    "type": "array",
+				    "items": {
+				        "type": "number"
+				    }
+				},
 				"ntia-nasctn-sea:median_of_mean_channel_powers": {
 					"type": "array",
 					"items": {
@@ -872,6 +884,30 @@
 			},
 			"additionalProperties": false
 		},
+		"Software": {
+		    "type": "object",
+		    "properties": {
+		        "system_platform": {
+		            "type": "string"
+		        },
+		        "python_version": {
+		            "type": "string"
+		        },
+		        "scos_sensor_version": {
+		            "type": "string"
+		        },
+		        "scos_actions_version": {
+		            "type": "string"
+		        },
+		        "scos_tekrsa_version": {
+		            "type": "string"
+		        },
+		        "preselector_api_version": {
+		            "type": "string"
+		        }
+		    },
+		    "additionalProperties": false
+		},
 		"SPU": {
 			"type": "object",
 			"properties": {
@@ -911,6 +947,9 @@
 				},
 				"preselector": {
 					"$ref": "#/$defs/PreselectorDiagnostics"
+				},
+				"software": {
+				    "$ref": "#/$defs/Software"
 				},
 				"spu": {
 					"$ref": "#/$defs/SPU"

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -1,4 +1,4 @@
-# The `ntia-diagnostics` SigMF Extension Namespace v1.1.0
+# The `ntia-diagnostics` SigMF Extension Namespace v1.1.1
 
 This document defines the `ntia-diagnostics` extension namespace for the Signal Metadata Format (SigMF) specification. This extension namespace provides metadata to describe system diagnostic information.
 
@@ -100,6 +100,7 @@ The `Software` versions object has the following properties:
 | `python_version`          | false    | string | [Semantic version](https://semver.org/) of Python used by the generator                                                                              |
 | `scos_sensor_version`     | false    | string | The [SCOS Sensor](https://github.com/NTIA/scos-sensor) version of the generator, in the form output by `git describe --tags`, e.g., "1.0.0-gebbc956" |
 | `scos_actions_version`    | false    | string | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator                     |
+| `scos_tekrsa_version`     | false    | string | [Semantic version](https://semver.org/) of the [SCOS TekRSA](https://github.com/NTIA/scos-tekrsa) plugin used by the generator                       |
 | `preselector_api_version` | false    | string | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator                      |
 
 ## 1 Global
@@ -137,7 +138,7 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
       "optional" : false
     }, {
       "name" : "ntia-diagnostics",
-      "version" : "v1.1.0",
+      "version" : "v1.1.1",
       "optional" : false
     } ],
     "ntia-core:classification" : "UNCLASSIFIED",
@@ -153,7 +154,7 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
         "cpu_overheating" : false,
         "cpu_uptime" : 10.0,
         "scos_uptime" : 1.0,
-        "scos_start" : "2023-09-09T10:17:29.726Z",
+        "scos_start" : "2023-10-18T20:33:43.779Z",
         "ssd_smart_data" : {
           "temp" : 41.0,
           "test_passed" : true,
@@ -165,7 +166,7 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
           "integrity_errors" : 0
         }
       },
-      "datetime" : "2023-09-09T10:17:29.722Z",
+      "datetime" : "2023-10-18T20:33:43.776Z",
       "preselector" : {
         "temp" : 21.6,
         "humidity" : 65.0,
@@ -178,6 +179,7 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
         "python_version" : "3.11.5",
         "scos_sensor_version" : "1.0.0-gcbb75ad",
         "scos_actions_version" : "2.0.0",
+        "scos_tekrsa_version" : "3.1.3",
         "preselector_api_version" : "1.0.0"
       },
       "spu" : {


### PR DESCRIPTION
- Add `scos_tekrsa_version` field to software diagnostics object, updating the markdown spec and related Java classes, tests, and example generators
- Update the schema for these changes and those in #45 
- Bump the overall package version from 2.0.2 to 2.0.3