### PR TITLE
`ntia-diagnostics` v1.1.2

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -14,7 +14,7 @@ def versions = [
 def archiveBaseName= 'sigmf-ns-ntia'
 
 group = 'gov.doc.ntia'
-version = '2.0.4'
+version = '2.0.3'
 
 sourceCompatibility = 1.8
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -14,7 +14,7 @@ def versions = [
 def archiveBaseName= 'sigmf-ns-ntia'
 
 group = 'gov.doc.ntia'
-version = '2.0.3'
+version = '2.0.4'
 
 sourceCompatibility = 1.8
 

--- a/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
@@ -8,6 +8,7 @@ import gov.doc.ntia.sigmf.examples.ExampleUtils;
 import gov.doc.ntia.sigmf.ext.diagnostics.Computer;
 import gov.doc.ntia.sigmf.ext.diagnostics.Diagnostics;
 import gov.doc.ntia.sigmf.ext.diagnostics.Preselector;
+import gov.doc.ntia.sigmf.ext.diagnostics.ScosPlugin;
 import gov.doc.ntia.sigmf.ext.diagnostics.Software;
 import gov.doc.ntia.sigmf.ext.diagnostics.SPU;
 import gov.doc.ntia.sigmf.ext.diagnostics.SsdSmartData;
@@ -17,7 +18,7 @@ public class DiagnosticsExample implements Example {
   public static Extension getExtension() {
     Extension extension = new Extension();
     extension.setName("ntia-diagnostics");
-    extension.setVersion("v1.1.1");
+    extension.setVersion("v1.1.2");
     extension.setOptional(false);
     return extension;
   }
@@ -59,7 +60,10 @@ public class DiagnosticsExample implements Example {
     software.setPythonVersion("3.11.5");
     software.setScosSensorVersion("1.0.0-gcbb75ad");
     software.setScosActionsVersion("2.0.0");
-    software.setScosTekrsaVersion("3.1.3");
+    ScosPlugin scosSiganPlugin = new ScosPlugin();
+    scosSiganPlugin.setName("scos_tekrsa");
+    scosSiganPlugin.setVersion("3.1.4");
+    software.setScosSiganPlugin(scosSiganPlugin);
     software.setPreselectorApiVersion("1.0.0");
     return software;
   }

--- a/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/ScosPlugin.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/ScosPlugin.java
@@ -1,0 +1,34 @@
+package gov.doc.ntia.sigmf.ext.diagnostics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ScosPlugin {
+
+  @NotNull
+  @JsonProperty(required = true)
+  protected String name;
+
+  @NotNull
+  @JsonProperty(required = true)
+  protected String version;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+}

--- a/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Software.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Software.java
@@ -18,8 +18,8 @@ public class Software {
     @JsonProperty(value = "scos_actions_version")
     protected String scosActionsVersion;
 
-    @JsonProperty(value = "scos_tekrsa_version")
-    protected String scosTekrsaVersion;
+    @JsonProperty(value = "scos_sigan_plugin")
+    protected ScosPlugin scosSiganPlugin;
 
     @JsonProperty(value = "preselector_api_version")
     protected String preselectorApiVersion;
@@ -56,9 +56,9 @@ public class Software {
         this.scosActionsVersion = scosActionsVersion;
     }
 
-    public String getScosTekrsaVersion() { return scosTekrsaVersion; }
+    public ScosPlugin getScosSiganPlugin() { return scosSiganPlugin; }
 
-    public void setScosTekrsaVersion(String scosTekrsaVersion) { this.scosTekrsaVersion = scosTekrsaVersion; }
+    public void setScosSiganPlugin(ScosPlugin scosSiganPlugin) { this.scosSiganPlugin = scosSiganPlugin; }
 
     public String getPreselectorApiVersion() {
         return preselectorApiVersion;

--- a/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
+++ b/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
@@ -244,7 +244,8 @@ public class NasctnSensorTest {
     Assertions.assertEquals("Linux-5.4.0-153-generic-x86_64-with-glibc2.29", software.getSystemPlatform());
     Assertions.assertEquals("3.8.10", software.getPythonVersion());
     Assertions.assertEquals("6.3.3", software.getScosActionsVersion());
-    Assertions.assertEquals("3.1.3", software.getScosTekrsaVersion());
+    Assertions.assertEquals("scos_tekrsa", software.getScosSiganPlugin().getName());
+    Assertions.assertEquals("3.1.4", software.getScosSiganPlugin().getVersion());
     Assertions.assertEquals( "3.0.2", software.getPreselectorApiVersion());
     Assertions.assertEquals("1.0.0-gcbb75ad", software.getScosSensorVersion());
   }

--- a/java/src/test/resources/meta.sigmf-meta
+++ b/java/src/test/resources/meta.sigmf-meta
@@ -14,7 +14,7 @@
       },
       {
         "name": "ntia-diagnostics",
-        "version": "v1.1.1",
+        "version": "v1.1.2",
         "optional": true
       },
       {
@@ -257,7 +257,10 @@
         "system_platform": "Linux-5.4.0-153-generic-x86_64-with-glibc2.29",
         "python_version": "3.8.10",
         "scos_actions_version": "6.3.3",
-        "scos_tekrsa_version": "3.1.3",
+        "scos_sigan_plugin": {
+            "name": "scos_tekrsa",
+            "version": "3.1.4"
+        },
         "preselector_api_version": "3.0.2",
         "scos_sensor_version": "1.0.0-gcbb75ad"
       },

--- a/java/src/test/resources/sigmf-ns-ntia.schema
+++ b/java/src/test/resources/sigmf-ns-ntia.schema
@@ -884,6 +884,18 @@
 			},
 			"additionalProperties": false
 		},
+		"ScosPlugin": {
+		    "type": "object",
+		    "properties": {
+		        "name": {
+		            "type": "string"
+		        },
+		        "version": {
+		            "type": "string"
+		        }
+		    },
+		    "additionalProperties": false
+		},
 		"Software": {
 		    "type": "object",
 		    "properties": {
@@ -899,8 +911,8 @@
 		        "scos_actions_version": {
 		            "type": "string"
 		        },
-		        "scos_tekrsa_version": {
-		            "type": "string"
+		        "scos_sigan_plugin": {
+		            "$ref": "#/$defs/ScosPlugin"
 		        },
 		        "preselector_api_version": {
 		            "type": "string"

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -6,14 +6,15 @@ This document defines the `ntia-diagnostics` extension namespace for the Signal 
 
 The `ntia-diagnostics` extension defines the following datatypes:
 
-|name|long-form name|description|
-|----|--------------|-----------|
-|`Diagnostics`|general diagnostics information|JSON [Diagnostics](#01-the-diagnostics-object) object containing general diagnostics information and sub-objects with diagnostics from specific components|
-|`Preselector`|preselector diagnostics|JSON [Preselector](#02-the-preselector-diagnostics-object) object containing diagnostics for a preselector|
-|`SPU`|signal processing unit diagnostics|JSON [SPU](#03-the-spu-diagnostics-object) object containing diagnostics for a signal processing unit|
-|`Computer`|computer diagnostics|JSON [Computer](#04-the-computer-diagnostics-object) object containing diagnostics for a computer which runs SCOS|
-|`Software`|software versions|JSON [Software](#06-the-software-versions-object) object containing software version information|
-|`SsdSmartData`|solid-state drive SMART diagnostics|JSON [SsdSmartData](#05-the-ssdsmartdata-diagnostics-object) object containing results of SMART diagnostics for an SSD|
+| name           | long-form name                      | description                                                                                                                                                |
+|----------------|-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Diagnostics`  | general diagnostics information     | JSON [Diagnostics](#01-the-diagnostics-object) object containing general diagnostics information and sub-objects with diagnostics from specific components |
+| `Preselector`  | preselector diagnostics             | JSON [Preselector](#02-the-preselector-diagnostics-object) object containing diagnostics for a preselector                                                 |
+| `SPU`          | signal processing unit diagnostics  | JSON [SPU](#03-the-spu-diagnostics-object) object containing diagnostics for a signal processing unit                                                      |
+| `Computer`     | computer diagnostics                | JSON [Computer](#04-the-computer-diagnostics-object) object containing diagnostics for a computer which runs SCOS                                          |
+| `Software`     | software versions                   | JSON [Software](#06-the-software-versions-object) object containing software version information                                                           |
+| `SsdSmartData` | solid-state drive SMART diagnostics | JSON [SsdSmartData](#05-the-ssdsmartdata-diagnostics-object) object containing results of SMART diagnostics for an SSD                                     |
+| `ScosPlugin`   | SCOS plugins                        | JSON [ScosPlugin](#07-the-scos-plugin-object) object containing SCOS plugin names and versions                                                             |
 
 Multiple key/value pairs in the objects defined by this extension MUST be ISO-8601 strings, as defined by [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt), where the only allowed `time-offset` is `z`, indicating the UTC/Zulu timezone. Thus, timestamps take the form of `YYYY-MM-DDTHH:MM:SS.SSSZ`, where any number of digits for fractional seconds is permitted.
 
@@ -94,14 +95,23 @@ The `SsdSmartData` diagnostics object has the following properties:
 
 The `Software` versions object has the following properties:
 
-| name                      | required | type   | description                                                                                                                                          |
-|---------------------------|----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `system_platform`         | false    | string | A human-readable representation of the generator's software platform, e.g. "Linux-5.4.0-153-generic-x86_64-with-glibc2.29"                           |
-| `python_version`          | false    | string | [Semantic version](https://semver.org/) of Python used by the generator                                                                              |
-| `scos_sensor_version`     | false    | string | The [SCOS Sensor](https://github.com/NTIA/scos-sensor) version of the generator, in the form output by `git describe --tags`, e.g., "1.0.0-gebbc956" |
-| `scos_actions_version`    | false    | string | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator                     |
-| `scos_sigan_version`      | false    | string | [Semantic version](https://semver.org/) of the [SCOS TekRSA](https://github.com/NTIA/scos-tekrsa) plugin used by the generator                       |
-| `preselector_api_version` | false    | string | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator                      |
+| name                      | required | type         | description                                                                                                                                          |
+|---------------------------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `system_platform`         | false    | string       | A human-readable representation of the generator's software platform, e.g. "Linux-5.4.0-153-generic-x86_64-with-glibc2.29"                           |
+| `python_version`          | false    | string       | [Semantic version](https://semver.org/) of Python used by the generator                                                                              |
+| `scos_sensor_version`     | false    | string       | The [SCOS Sensor](https://github.com/NTIA/scos-sensor) version of the generator, in the form output by `git describe --tags`, e.g., "1.0.0-gebbc956" |
+| `scos_actions_version`    | false    | string       | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator                     |
+| `scos_sigan`              | false    | `ScosPlugin` | [ScosPlugin](#07-the-scos-plugin-object) object containing the SCOS plugin name and version for the signal analyzer interface                        |
+| `preselector_api_version` | false    | string       | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator                      |
+
+### 0.7 The SCOS Plugin Object
+
+The ``ScosPlugin``
+
+| name      | required | type   | description                                                                |
+|-----------|----------|--------|----------------------------------------------------------------------------|
+| `name`    | true     | string | Python package name as it is imported, e.g., `"scos_tekrsa`"               |
+| `version` | false    | string | [Semantic version](https://semver.org/) of the SCOS signal analyzer plugin |
 
 ## 1 Global
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -111,7 +111,7 @@ The ``ScosPlugin`` object has the following properties:
 | name      | required | type   | description                                                  |
 |-----------|----------|--------|--------------------------------------------------------------|
 | `name`    | true     | string | Python package name as it is imported, e.g., `"scos_tekrsa`" |
-| `version` | false    | string | [Semantic version](https://semver.org/) of the SCOS plugin   |
+| `version` | true     | string | [Semantic version](https://semver.org/) of the SCOS plugin   |
 
 ## 1 Global
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -101,17 +101,17 @@ The `Software` versions object has the following properties:
 | `python_version`          | false    | string       | [Semantic version](https://semver.org/) of Python used by the generator                                                                              |
 | `scos_sensor_version`     | false    | string       | The [SCOS Sensor](https://github.com/NTIA/scos-sensor) version of the generator, in the form output by `git describe --tags`, e.g., "1.0.0-gebbc956" |
 | `scos_actions_version`    | false    | string       | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator                     |
-| `scos_sigan`              | false    | `ScosPlugin` | [ScosPlugin](#07-the-scos-plugin-object) object containing the SCOS plugin name and version for the signal analyzer interface                        |
+| `scos_sigan_plugin`       | false    | `ScosPlugin` | [ScosPlugin](#07-the-scos-plugin-object) object containing the name and version of the plugin defining the signal analyzer interfa                   |
 | `preselector_api_version` | false    | string       | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator                      |
 
 ### 0.7 The SCOS Plugin Object
 
 The ``ScosPlugin`` object has the following properties: 
 
-| name      | required | type   | description                                                                |
-|-----------|----------|--------|----------------------------------------------------------------------------|
-| `name`    | true     | string | Python package name as it is imported, e.g., `"scos_tekrsa`"               |
-| `version` | false    | string | [Semantic version](https://semver.org/) of the SCOS signal analyzer plugin |
+| name      | required | type   | description                                                  |
+|-----------|----------|--------|--------------------------------------------------------------|
+| `name`    | true     | string | Python package name as it is imported, e.g., `"scos_tekrsa`" |
+| `version` | false    | string | [Semantic version](https://semver.org/) of the SCOS plugin   |
 
 ## 1 Global
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -148,7 +148,7 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
       "optional" : false
     }, {
       "name" : "ntia-diagnostics",
-      "version" : "v1.1.1",
+      "version" : "v1.1.2",
       "optional" : false
     } ],
     "ntia-core:classification" : "UNCLASSIFIED",
@@ -164,7 +164,7 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
         "cpu_overheating" : false,
         "cpu_uptime" : 10.0,
         "scos_uptime" : 1.0,
-        "scos_start" : "2023-10-18T20:33:43.779Z",
+        "scos_start" : "2023-10-20T19:56:29.601Z",
         "ssd_smart_data" : {
           "temp" : 41.0,
           "test_passed" : true,
@@ -176,7 +176,7 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
           "integrity_errors" : 0
         }
       },
-      "datetime" : "2023-10-18T20:33:43.776Z",
+      "datetime" : "2023-10-20T19:56:29.597Z",
       "preselector" : {
         "temp" : 21.6,
         "humidity" : 65.0,
@@ -189,7 +189,10 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
         "python_version" : "3.11.5",
         "scos_sensor_version" : "1.0.0-gcbb75ad",
         "scos_actions_version" : "2.0.0",
-        "scos_tekrsa_version" : "3.1.3",
+        "scos_sigan_plugin" : {
+          "name" : "scos_tekrsa",
+          "version" : "3.1.4"
+        },
         "preselector_api_version" : "1.0.0"
       },
       "spu" : {

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -106,7 +106,7 @@ The `Software` versions object has the following properties:
 
 ### 0.7 The SCOS Plugin Object
 
-The ``ScosPlugin``
+The ``ScosPlugin`` object has the following properties: 
 
 | name      | required | type   | description                                                                |
 |-----------|----------|--------|----------------------------------------------------------------------------|

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -21,74 +21,74 @@ Multiple key/value pairs in the objects defined by this extension MUST be ISO-86
 
 `Diagnostics` has the following properties:
 
-| name             |required| type                                                  | unit    | description                                                                         |
-|------------------|--------------|-------------------------------------------------------|---------|-------------------------------------------------------------------------------------|
-| `datetime`       |false| string                                                |ISO-8601 (see above)| The time at which the diagnostics were gathered. |
-| `preselector`    |false| [Preselector](#02-the-preselector-diagnostics-object) | N/A     | Metadata to capture preselector diagnostics.                                        |
-| `spu`            |false| [SPU](#03-the-spu-diagnostics-object)                 | N/A     | Metadata to capture signal processing unit diagnostics.                             |
-| `computer`       |false| [Computer](#04-the-computer-diagnostics-object)       | N/A     | Metadata to capture computer diagnostics.                                           |
-| `software`       |false| [Software](#06-the-software-versions-object)          | N/A     | Metadata to capture software versions.                                              |
-| `action_runtime` |false| double                                                | seconds | Total action execution time.                                                        |
+| name             | required | type                                                  | unit                 | description                                             |
+|------------------|----------|-------------------------------------------------------|----------------------|---------------------------------------------------------|
+| `datetime`       | false    | string                                                | ISO-8601 (see above) | The time at which the diagnostics were gathered.        |
+| `preselector`    | false    | [Preselector](#02-the-preselector-diagnostics-object) | N/A                  | Metadata to capture preselector diagnostics.            |
+| `spu`            | false    | [SPU](#03-the-spu-diagnostics-object)                 | N/A                  | Metadata to capture signal processing unit diagnostics. |
+| `computer`       | false    | [Computer](#04-the-computer-diagnostics-object)       | N/A                  | Metadata to capture computer diagnostics.               |
+| `software`       | false    | [Software](#06-the-software-versions-object)          | N/A                  | Metadata to capture software versions.                  |
+| `action_runtime` | false    | double                                                | seconds              | Total action execution time.                            |
 
 ### 0.2 The `Preselector` Diagnostics Object
 
 The `Preselector` diagnostics object has the following properties:
 
-| name                   |required| type                                  | unit           | description                                                     |
-|------------------------|--------------|---------------------------------------|----------------|-----------------------------------------------------------------|
-|`temp`|false|double| degree Celsius | Temperature inside the preselector enclosure.                   |
-|`noise_diode_temp`|false|double| degree Celsius | Temperature of the noise diode.                                 |
-|`lna_temp`|false|double| degree Celsius | Temperature of the low noise amplifier.                         |
-|`humidity`|false|double| percent        | Relative humidity inside the preselector enclosure.             |
-|`door_closed`|false|boolean| N/A            | Boolean indicating whether the door of the enclosure is closed. |
+| name               | required | type    | unit           | description                                                     |
+|--------------------|----------|---------|----------------|-----------------------------------------------------------------|
+| `temp`             | false    | double  | degree Celsius | Temperature inside the preselector enclosure.                   |
+| `noise_diode_temp` | false    | double  | degree Celsius | Temperature of the noise diode.                                 |
+| `lna_temp`         | false    | double  | degree Celsius | Temperature of the low noise amplifier.                         |
+| `humidity`         | false    | double  | percent        | Relative humidity inside the preselector enclosure.             |
+| `door_closed`      | false    | boolean | N/A            | Boolean indicating whether the door of the enclosure is closed. |
 
 ### 0.3 The `SPU` Diagnostics Object
 
 The `SPU` diagnostics object has the following properties, which are defined based on the components of an SPU in a NASCTN SEA Prototype Rev3 sensor:
 
-| name                  |required| type    | unit           | description                                              |
-|-----------------------|--------------|---------|----------------|----------------------------------------------------------|
-| `rf_tray_powered`     |false| boolean | N/A            | Boolean indicating if the RF tray is powered.            |
-| `preselector_powered` |false| boolean | N/A            | Boolean indicating if the preselector is powered.        |
-| `28v_aux_powered`     |false| boolean | N/A            | Boolean indicating if the 28 volt auxillary power is on. |
-| `pwr_box_temp`        |false| double  | degree Celsius | Ambient temperature at power distribution.               |
-| `pwr_box_humidity`    |false| double  | percent        | Humidity at power distribution.                          |
-| `rf_box_temp`         |false| double  | degree Celsius | Ambient temperature around the signal analyzer.          |
-| `sigan_internal_temp` |false| double  | degree Celsius | Internal temperature reported by the signal analyzer     |
+| name                  | required | type    | unit           | description                                              |
+|-----------------------|----------|---------|----------------|----------------------------------------------------------|
+| `rf_tray_powered`     | false    | boolean | N/A            | Boolean indicating if the RF tray is powered.            |
+| `preselector_powered` | false    | boolean | N/A            | Boolean indicating if the preselector is powered.        |
+| `28v_aux_powered`     | false    | boolean | N/A            | Boolean indicating if the 28 volt auxillary power is on. |
+| `pwr_box_temp`        | false    | double  | degree Celsius | Ambient temperature at power distribution.               |
+| `pwr_box_humidity`    | false    | double  | percent        | Humidity at power distribution.                          |
+| `rf_box_temp`         | false    | double  | degree Celsius | Ambient temperature around the signal analyzer.          |
+| `sigan_internal_temp` | false    | double  | degree Celsius | Internal temperature reported by the signal analyzer     |
 
 ### 0.4 The `Computer` Diagnostics Object
 
 The `Computer` diagnostics object has the following properties:
 
-| name               |required| type                                                    | unit           | description                                                                                             |
-|--------------------|--------------|---------------------------------------------------------|----------------|---------------------------------------------------------------------------------------------------------|
-| `cpu_min_clock`  |false| double                                                  | MHz            | Minimum sampled clock speed.                                                                            |
-| `cpu_max_clock`  |false| double                                                  | MHz            | Maximum sampled clock speed.                                                                            |
-| `cpu_mean_clock` |false| double                                                  | MHz            | Mean sampled clock speed.                                                                               |
-| `cpu_uptime`        |false| double                                                  |days| Number of days since the computer started                        |
-| `action_cpu_usage`        |false| double                                                  | percent        | CPU utilization during action execution.                                                                |
-| `system_load_5m`          |false| double                                                  | percent        | Number of processes in a runnable state over the previous 5 minutes as a percent of the number of CPUs. |
-| `memory_usage`     |false| double                                                  | percent        | Average percent of memory used during action execution.                                                  |
-| `cpu_overheating`      |false| boolean                                                 | N/A            | True if the CPU is overheating.                                                                             |
-| `cpu_temp`             |false| double                                                  | degree Celsius | CPU temperature.                                                                                   |
-| `scos_start`       |false| string                                                  |ISO-8601 (see above)| The time at which the SCOS API container started.                   |
-| `scos_uptime`      |false| double                                                  | days           | Number of days since the SCOS API container started.                                                    |
-| `ssd_smart_data`   |false| [SsdSmartData](#05-the-ssdsmartdata-diagnostics-object) | N/A           | Information provided by the drive Self-Monitoring, Analysis, and Reporting Technology.                  |
+| name               | required | type                                                    | unit                 | description                                                                                             |
+|--------------------|----------|---------------------------------------------------------|----------------------|---------------------------------------------------------------------------------------------------------|
+| `cpu_min_clock`    | false    | double                                                  | MHz                  | Minimum sampled clock speed.                                                                            |
+| `cpu_max_clock`    | false    | double                                                  | MHz                  | Maximum sampled clock speed.                                                                            |
+| `cpu_mean_clock`   | false    | double                                                  | MHz                  | Mean sampled clock speed.                                                                               |
+| `cpu_uptime`       | false    | double                                                  | days                 | Number of days since the computer started                                                               |
+| `action_cpu_usage` | false    | double                                                  | percent              | CPU utilization during action execution.                                                                |
+| `system_load_5m`   | false    | double                                                  | percent              | Number of processes in a runnable state over the previous 5 minutes as a percent of the number of CPUs. |
+| `memory_usage`     | false    | double                                                  | percent              | Average percent of memory used during action execution.                                                 |
+| `cpu_overheating`  | false    | boolean                                                 | N/A                  | True if the CPU is overheating.                                                                         |
+| `cpu_temp`         | false    | double                                                  | degree Celsius       | CPU temperature.                                                                                        |
+| `scos_start`       | false    | string                                                  | ISO-8601 (see above) | The time at which the SCOS API container started.                                                       |
+| `scos_uptime`      | false    | double                                                  | days                 | Number of days since the SCOS API container started.                                                    |
+| `ssd_smart_data`   | false    | [SsdSmartData](#05-the-ssdsmartdata-diagnostics-object) | N/A                  | Information provided by the drive Self-Monitoring, Analysis, and Reporting Technology.                  |
 
 ### 0.5 The `SsdSmartData` Diagnostics Object
 
 The `SsdSmartData` diagnostics object has the following properties:
 
-| name                        |required| type    | unit           | description                                                                                                                                                                                                                                                                                                                                                                                           |
-|-----------------------------|--------------|---------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `test_passed`               |false| boolean | N/A            | SMART overall-health self-assessment test result.                                                                                                                                                                                                                                                                                                                                                     |
-| `critical_warning`          |false| string     | N/A            | Critical warning message from smartctl, a string containing a hexadecimal value, e.g., `"0x00"`                                                                                                                                                                                                                                                                                                                                                                      |
-| `temp`                      |false| double  | degree Celsius | Drive temperature.                                                                                                                                                                                                                                                                                                                                                                                    |
-| `available_spare`           |false| double  | percent        | Normalized percentage (0 to 100%) of the remaining spare capacity available.                                                                                                                                                                                                                                                                                                                          |
-| `available_spare_threshold` |false| double  | percent           | When the available_spare falls below the threshold indicated in this field, an asynchronous event completion may occur. The value is indicated as a normalized percentage (0 to 100%).                                                                                                                                                                                                                |
-| `percentage_used`           |false| double  | percent        | Contains a vendor specific estimate of the percentage of NVM subsystem life used based on the actual usage and the manufacturer’s prediction of NVM life. A value of 100 indicates that the estimated endurance of the NVM in the NVM subsystem has been consumed, but may not indicate an NVM subsystem failure. Values may exceed 100 and percentages greater than 254 shall be represented as 255. |
-| `unsafe_shutdowns`          |false| int     | N/A            | Number of unsafe shutdowns.                                                                                                                                                                                                                                                                                                                                                                           |
-| `integrity_errors`          |false| int     | N/A            | Number of occurrences where the controller detected an unrecovered data integrity error                  |
+| name                        | required | type    | unit           | description                                                                                                                                                                                                                                                                                                                                                                                           |
+|-----------------------------|----------|---------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `test_passed`               | false    | boolean | N/A            | SMART overall-health self-assessment test result.                                                                                                                                                                                                                                                                                                                                                     |
+| `critical_warning`          | false    | string  | N/A            | Critical warning message from smartctl, a string containing a hexadecimal value, e.g., `"0x00"`                                                                                                                                                                                                                                                                                                       |
+| `temp`                      | false    | double  | degree Celsius | Drive temperature.                                                                                                                                                                                                                                                                                                                                                                                    |
+| `available_spare`           | false    | double  | percent        | Normalized percentage (0 to 100%) of the remaining spare capacity available.                                                                                                                                                                                                                                                                                                                          |
+| `available_spare_threshold` | false    | double  | percent        | When the available_spare falls below the threshold indicated in this field, an asynchronous event completion may occur. The value is indicated as a normalized percentage (0 to 100%).                                                                                                                                                                                                                |
+| `percentage_used`           | false    | double  | percent        | Contains a vendor specific estimate of the percentage of NVM subsystem life used based on the actual usage and the manufacturer’s prediction of NVM life. A value of 100 indicates that the estimated endurance of the NVM in the NVM subsystem has been consumed, but may not indicate an NVM subsystem failure. Values may exceed 100 and percentages greater than 254 shall be represented as 255. |
+| `unsafe_shutdowns`          | false    | int     | N/A            | Number of unsafe shutdowns.                                                                                                                                                                                                                                                                                                                                                                           |
+| `integrity_errors`          | false    | int     | N/A            | Number of occurrences where the controller detected an unrecovered data integrity error                                                                                                                                                                                                                                                                                                               |
 
 ### 0.6 The Software Versions Object
 
@@ -100,16 +100,16 @@ The `Software` versions object has the following properties:
 | `python_version`          | false    | string | [Semantic version](https://semver.org/) of Python used by the generator                                                                              |
 | `scos_sensor_version`     | false    | string | The [SCOS Sensor](https://github.com/NTIA/scos-sensor) version of the generator, in the form output by `git describe --tags`, e.g., "1.0.0-gebbc956" |
 | `scos_actions_version`    | false    | string | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator                     |
-| `scos_tekrsa_version`     | false    | string | [Semantic version](https://semver.org/) of the [SCOS TekRSA](https://github.com/NTIA/scos-tekrsa) plugin used by the generator                       |
+| `scos_sigan_version`      | false    | string | [Semantic version](https://semver.org/) of the [SCOS TekRSA](https://github.com/NTIA/scos-tekrsa) plugin used by the generator                       |
 | `preselector_api_version` | false    | string | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator                      |
 
 ## 1 Global
 
 The `ntia-sensor` extension adds the following name/value pairs to the `global` SigMF object:
 
-| name                   |required| type                                  |unit| description                                   |
-|------------------------|--------------|---------------------------------------|-------|-----------------------------------------------|
-| `diagnostics`          |false| [Diagnostics](#01-the-diagnostics-object) |N/A| Metadata for capturing component diagnostics. |
+| name          | required | type                                      | unit | description                                   |
+|---------------|----------|-------------------------------------------|------|-----------------------------------------------|
+| `diagnostics` | false    | [Diagnostics](#01-the-diagnostics-object) | N/A  | Metadata for capturing component diagnostics. |
 
 ## 2 Captures
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -101,7 +101,7 @@ The `Software` versions object has the following properties:
 | `python_version`          | false    | string       | [Semantic version](https://semver.org/) of Python used by the generator                                                                              |
 | `scos_sensor_version`     | false    | string       | The [SCOS Sensor](https://github.com/NTIA/scos-sensor) version of the generator, in the form output by `git describe --tags`, e.g., "1.0.0-gebbc956" |
 | `scos_actions_version`    | false    | string       | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator                     |
-| `scos_sigan_plugin`       | false    | `ScosPlugin` | [ScosPlugin](#07-the-scos-plugin-object) object containing the name and version of the plugin defining the signal analyzer interfa                   |
+| `scos_sigan_plugin`       | false    | `ScosPlugin` | [ScosPlugin](#07-the-scos-plugin-object) object containing the name and version of the plugin implementing the signal analyzer interface             |
 | `preselector_api_version` | false    | string       | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator                      |
 
 ### 0.7 The SCOS Plugin Object


### PR DESCRIPTION
Replace the software diagnostics `scos_tekrsa_version` with a more general `scos_sigan_plugin` field, which is populated by a new object defined by `ntia-diagnostics`: the `ScosPlugin` object. This object contains a name and version field.

Updated markdown specs, Java, and examples.