### PR TITLE
Add missing SPU fields to Java implementation. 

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -14,7 +14,7 @@ def versions = [
 def archiveBaseName= 'sigmf-ns-ntia'
 
 group = 'gov.doc.ntia'
-version = '3.0.0'
+version = '3.0.1'
 
 
 repositories {

--- a/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/SPU.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/SPU.java
@@ -7,6 +7,9 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SPU {
 
+  @JsonProperty(value = "low_battery")
+  protected Boolean lowBattery;
+
   @JsonProperty(value = "battery_backup")
   protected Boolean batteryBackup;
 
@@ -36,6 +39,12 @@ public class SPU {
 
   @JsonProperty(value = "power_sensors")
   protected List<DiagnosticSensor> powerSensors;
+
+  @JsonProperty(value = "ups_healthy")
+  protected Boolean upsHealthy;
+
+  @JsonProperty(value = "replace_battery")
+  protected Boolean replaceBattery;
 
   public Boolean getPreselectorPowered() {
     return preselectorPowered;
@@ -117,4 +126,27 @@ public class SPU {
     this.batteryBackup = batteryBackup;
   }
 
+  public Boolean getLowBattery() {
+    return lowBattery;
+  }
+
+  public void setLowBattery(Boolean lowBattery) {
+    this.lowBattery = lowBattery;
+  }
+
+  public Boolean getUpsHealthy() {
+    return upsHealthy;
+  }
+
+  public void setUpsHealthy(Boolean upsHealthy) {
+    this.upsHealthy = upsHealthy;
+  }
+
+  public Boolean getReplaceBattery() {
+    return replaceBattery;
+  }
+
+  public void setReplaceBattery(Boolean replaceBattery) {
+    this.replaceBattery = replaceBattery;
+  }
 }

--- a/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/SPU.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/SPU.java
@@ -7,6 +7,9 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SPU {
 
+  @JsonProperty(value = "battery_backup")
+  protected Boolean batteryBackup;
+
   @JsonProperty(value = "preselector_powered")
   protected Boolean preselectorPowered;
 
@@ -16,9 +19,11 @@ public class SPU {
   @JsonProperty(value = "temperature_control_powered")
   protected Boolean tempControlPowered;
 
-  @JsonProperty protected Boolean cooling;
+  @JsonProperty
+  protected Boolean cooling;
 
-  @JsonProperty protected Boolean heating;
+  @JsonProperty
+  protected Boolean heating;
 
   @JsonProperty(value = "door_closed")
   protected Boolean doorClosed;
@@ -103,4 +108,13 @@ public class SPU {
   public void setPowerSensors(List<DiagnosticSensor> powerSensors) {
     this.powerSensors = powerSensors;
   }
+
+  public Boolean getBatteryBackup() {
+    return batteryBackup;
+  }
+
+  public void setBatteryBackup(Boolean batteryBackup) {
+    this.batteryBackup = batteryBackup;
+  }
+
 }

--- a/java/src/test/resources/meta.sigmf-meta
+++ b/java/src/test/resources/meta.sigmf-meta
@@ -297,7 +297,11 @@
         "humidity": 17.0
       },
       "spu": {
+        "replace_battery": false,
+        "battery_backup": false,
+        "ups_healthy": true,
         "door_closed": true,
+        "low_battery": false,
         "sigan_powered": true,
         "temperature_control_powered": false,
         "preselector_powered": true,

--- a/java/src/test/resources/sigmf-ns-ntia.schema
+++ b/java/src/test/resources/sigmf-ns-ntia.schema
@@ -968,7 +968,7 @@
 				"low_battery":{
 				    "type": "boolean"
 				},
-				"battery_healthy":{
+				"replace_battery":{
 				    "type": "boolean"
 				},
 				"ups_healthy":{

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -195,6 +195,11 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
 				"noise_diode_path_enabled": false
 			},
 			"spu": {
+                "replace_battery": false,
+                "battery_backup": false,
+                "ups_healthy": true,
+                "door_closed": true,
+                "low_battery": false,
 				"sigan_powered": true,
 				"temperature_control_powered": false,
 				"preselector_powered": true,

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -64,7 +64,7 @@ The `SPU` diagnostics object has the following properties:
 | `cooling`                     | false    | boolean                                                   | N/A            | Boolean indicating whether the cooling is on.                      |
 | `battery_backup`              | false    | boolean                                                   | N/A            | Boolean indicating True if the device is running on battery backup |
 | `low_battery`                 | false    | boolean                                                   | N/A            | Boolean indicating True if the battery backup is low               |
-| `battery_healthy`             | false    | boolean                                                   | N/A            | Boolean indicating True if the battery backup needs to be replaced |
+| `replace_battery`             | false    | boolean                                                   | N/A            | Boolean indicating True if the battery backup needs to be replaced |
 | `ups_healthy`                 | false    | boolean                                                   | N/A            | Boolean indicating false if the UPS has a failure                  |
 
 


### PR DESCRIPTION
This adds fields to the SPU java implementation  that were specified in the markdown spec but missing from the Java class. In addition, it changes the battery_healthy field in the SPU to replace_battery. New Java implemenation has been tested on seadog03 running scos-sensor sea-prototype-v0.5.0.