### PR TITLE
`ntia-diagnostics` 2.1.0

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -14,7 +14,7 @@ def versions = [
 def archiveBaseName= 'sigmf-ns-ntia'
 
 group = 'gov.doc.ntia'
-version = '3.0.1'
+version = '3.1.0'
 
 
 repositories {

--- a/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
@@ -18,7 +18,7 @@ public class DiagnosticsExample implements Example {
   public static Extension getExtension() {
     Extension extension = new Extension();
     extension.setName("ntia-diagnostics");
-    extension.setVersion("v1.1.2");
+    extension.setVersion("v2.1.0");
     extension.setOptional(false);
     return extension;
   }
@@ -45,14 +45,15 @@ public class DiagnosticsExample implements Example {
 
   public static Preselector getPreselectorDiagnostics() {
     Preselector preselector = new Preselector();
-    preselector.setTemp(21.6);
+    preselector.setTemp(20.0);
     preselector.setNoiseDiodeTemp(21.8);
-    preselector.setLnaTemp(21.8);
+    preselector.setLnaTemp(22.5);
     preselector.setHumidity(65.0);
     preselector.setDoorClosed(true);
+    preselector.setNoiseDiodePowered(false);
+    preselector.setLnaPowered(true);
     preselector.setAntennaPathEnabled(true);
     preselector.setNoiseDiodePathEnabled(false);
-    preselector.setNoiseDiodePowered(false);
     return preselector;
   }
 
@@ -67,27 +68,38 @@ public class DiagnosticsExample implements Example {
     scosSiganPlugin.setVersion("3.1.4");
     software.setScosSiganPlugin(scosSiganPlugin);
     software.setPreselectorApiVersion("1.0.0");
+    software.setSiganFirmwareVersion("1.2.3");
+    software.setSiganApiVersion("V1.0.0");
     return software;
   }
 
   public static SPU getSPUDiagnostics() {
     SPU spu = new SPU();
+    spu.setSiganPowered(true);
     spu.setPreselectorPowered(true);
+
     DiagnosticSensor internalTemp = new DiagnosticSensor();
     internalTemp.setName("internal_temp");
     internalTemp.setValue(32.0);
     ArrayList<DiagnosticSensor> tempSensors = new ArrayList<>();
     tempSensors.add(internalTemp);
     spu.setTemperatureSensors(tempSensors);
+
     spu.setCooling(false);
     spu.setHeating(false);
     spu.setDoorClosed(true);
+    spu.setBatteryBackup(false);
+    spu.setLowBattery(false);
+    spu.setReplaceBattery(false);
+    spu.setUpsHealthy(true);
+
     DiagnosticSensor internalHumidity = new DiagnosticSensor();
     internalHumidity.setName("internal_humidity");
     internalHumidity.setValue(17.0);
     ArrayList<DiagnosticSensor> humiditySensors = new ArrayList<>();
     humiditySensors.add(internalHumidity);
     spu.setHumiditySensors(humiditySensors);
+
     DiagnosticSensor powerMonitor5V = new DiagnosticSensor();
     powerMonitor5V.setName("5V_power_monitor");
     powerMonitor5V.setValue(5.0);

--- a/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Software.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Software.java
@@ -24,6 +24,12 @@ public class Software {
     @JsonProperty(value = "preselector_api_version")
     protected String preselectorApiVersion;
 
+    @JsonProperty(value = "sigan_firmware_version")
+    protected String siganFirmwareVersion;
+
+    @JsonProperty(value = "sigan_api_version")
+    protected String siganApiVersion;
+
     public String getSystemPlatform() {
         return systemPlatform;
     }
@@ -66,5 +72,17 @@ public class Software {
 
     public void setPreselectorApiVersion(String preselectorApiVersion) {
         this.preselectorApiVersion = preselectorApiVersion;
+    }
+
+    public String getSiganFirmwareVersion() { return siganFirmwareVersion; }
+
+    public void setSiganFirmwareVersion(String siganFirmwareVersion) {
+        this.siganFirmwareVersion = siganFirmwareVersion;
+    }
+
+    public String getSiganApiVersion() { return siganApiVersion; }
+
+    public void setSiganApiVersion(String siganApiVersion) {
+        this.siganApiVersion = siganApiVersion;
     }
 }

--- a/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
+++ b/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
@@ -219,6 +219,8 @@ public class NasctnSensorTest {
     Assertions.assertEquals("3.1.5", software.getScosSiganPlugin().getVersion());
     Assertions.assertEquals( "3.1.0", software.getPreselectorApiVersion());
     Assertions.assertEquals("sea-prototype-v0.4.2-4-gbc10e57", software.getScosSensorVersion());
+    Assertions.assertEquals("1.2.3", software.getSiganFirmwareVersion());
+    Assertions.assertEquals("V1.0.0", software.getSiganApiVersion());
   }
 
   @Test

--- a/java/src/test/resources/meta.sigmf-meta
+++ b/java/src/test/resources/meta.sigmf-meta
@@ -14,7 +14,7 @@
       },
       {
         "name": "ntia-diagnostics",
-        "version": "v2.0.0",
+        "version": "v2.1.0",
         "optional": true
       },
       {
@@ -385,7 +385,9 @@
           "name": "scos_tekrsa",
           "version": "3.1.5"
         },
-        "preselector_api_version": "3.1.0"
+        "preselector_api_version": "3.1.0",
+        "sigan_firmware_version": "1.2.3",
+        "sigan_api_version": "V1.0.0"
       }
     },
     "core:sha512": "94a59d3d0e9fbf9a1775115c2c4ef69ab684cfd014f375257367c1ed7bddd63d28deb6dd18e259548a727eccfe3123c9bf7d613bdcef30a35ec8e52b1d9af268"

--- a/java/src/test/resources/sigmf-ns-ntia.schema
+++ b/java/src/test/resources/sigmf-ns-ntia.schema
@@ -937,6 +937,12 @@
 		        },
 		        "preselector_api_version": {
 		            "type": "string"
+		        },
+		        "sigan_firmware_version": {
+		            "type": "string"
+		        },
+		        "sigan_api_version": {
+		            "type": "string"
 		        }
 		    },
 		    "additionalProperties": false

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -43,6 +43,7 @@ The `Preselector` diagnostics object has the following properties:
 | `humidity`                 | false    | double  | percent        | Relative humidity inside the preselector enclosure.             |
 | `door_closed`              | false    | boolean | N/A            | Boolean indicating whether the door of the enclosure is closed. |
 | `noise_diode_powered`      | false    | boolean | N/A            | Boolean indicating whether the noise diode is powered.          |
+| `lna_powered`              | false    | boolean | N/A            | Boolean indicating whether the low noise amplifier is powered.  |
 | `antenna_path_enabled`     | false    | boolean | N/A            | Boolean indicating whether the antenna path is enabled.         |
 | `noise_diode_path_enabled` | false    | boolean | N/A            | Boolean indicating whether the noise diode path is enabled.     |
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -191,6 +191,7 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
     "ntia-core:classification" : "UNCLASSIFIED",
     "ntia-diagnostics:diagnostics" : {
       "computer" : {
+        "action_runtime" : 100.0,
         "cpu_max_clock" : 4800.0,
         "cpu_min_clock" : 1120.0,
         "cpu_mean_clock" : 3100.0,
@@ -205,16 +206,15 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
         "ntp_active" : true,
         "ntp_sync" : true,
         "ssd_smart_data" : {
-          "temp" : 41.0,
-          "test_passed" : true,
-          "critical_warning" : "0x00",
-          "available_spare" : 100.0,
-          "available_spare_threshold" : 10.0,
-          "percentage_used" : 1.0,
-          "unsafe_shutdowns" : 18,
-          "integrity_errors" : 0
-        },
-        "action_runtime" : 100.0
+          "temp": 41.0,
+          "test_passed": true,
+          "critical_warning": "0x00",
+          "available_spare": 100.0,
+          "available_spare_threshold": 10.0,
+          "percentage_used": 1.0,
+          "unsafe_shutdowns": 18,
+          "integrity_errors": 0
+        }
       },
       "datetime" : "2024-01-02T19:16:50.509Z",
       "preselector" : {

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -1,4 +1,4 @@
-# The `ntia-diagnostics` SigMF Extension Namespace v2.0.0
+# The `ntia-diagnostics` SigMF Extension Namespace v2.1.0
 
 This document defines the `ntia-diagnostics` extension namespace for the Signal Metadata Format (SigMF) specification. This extension namespace provides metadata to describe system diagnostic information.
 
@@ -120,6 +120,8 @@ The `Software` versions object has the following properties:
 | `scos_actions_version`    | false    | string       | [Semantic version](https://semver.org/) of the [SCOS Actions](https://github.com/NTIA/scos-actions) plugin used by the generator                     |
 | `scos_sigan_plugin`       | false    | `ScosPlugin` | [ScosPlugin](#07-the-scos-plugin-object) object containing the name and version of the plugin implementing the signal analyzer interface             |
 | `preselector_api_version` | false    | string       | [Semantic version](https://semver.org/) of the [ITS Preselector API](https://github.com/NTIA/Preselector) used by the generator                      |
+| `sigan_firmware_version`  | false    | string       | The version of the signal analyzer firmware, e.g. `"1.2"`, `"2.3.5"`, `"V3.4"`                                                                       |
+| `sigan_api_verision`      | false    | string       | The version of the signal analyzer API, e.g. `"v1.1.5"`, `"1.0.0"`, etc.                                                                             |
 
 ### 0.7 The SCOS Plugin Object
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -185,111 +185,87 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
       "optional" : false
     }, {
       "name" : "ntia-diagnostics",
-      "version" : "v2.0.0",
+      "version" : "v2.1.0",
       "optional" : false
     } ],
     "ntia-core:classification" : "UNCLASSIFIED",
-    "ntia-diagnostics:diagnostics": {
-			"datetime": "2023-12-01T16:45:51.618Z",
-			"preselector": {
-				"noise_diode_powered": false,
-				"lna_powered": true,
-				"antenna_path_enabled": true,
-				"noise_diode_path_enabled": false
-			},
-			"spu": {
-                "replace_battery": false,
-                "battery_backup": false,
-                "ups_healthy": true,
-                "door_closed": true,
-                "low_battery": false,
-				"sigan_powered": true,
-				"temperature_control_powered": false,
-				"preselector_powered": true,
-				"temperature_sensors": [
-					{
-						"name": "internal_temp",
-						"value": 22.0
-					},
-					{
-						"name": "sigan_internal_temp",
-						"value": 49.16
-					},
-					{
-						"name": "tec_intake_temp",
-						"value": 22.0
-					},
-					{
-						"name": "tec_exhaust_temp",
-						"value": 22.0
-					}
-				],
-				"humidity_sensors": [
-					{
-						"name": "internal_humidity",
-						"value": 55.3
-					}
-				],
-				"power_sensors": [
-					{
-						"name": "5v Monitor",
-						"value": 5.0,
-						"expected_value": 5.0
-					},
-					{
-						"name": "15v Monitor",
-						"value": 15.1,
-						"expected_value": 15.0
-					},
-					{
-						"name": "24v Monitor",
-						"value": 24.0,
-						"expected_value": 24.0
-					},
-					{
-						"name": "28v Monitor",
-						"value": 28.0,
-						"expected_value": 28.0
-					}
-				]
-			},
-			"computer": {
-				"cpu_min_clock": 1643.8,
-				"cpu_max_clock": 4528.6,
-				"cpu_mean_clock": 3295.3,
-				"cpu_uptime": 7.02,
-				"action_cpu_usage": 43.3,
-				"action_runtime": 92.58
-				"system_load_5m": 14.8,
-				"memory_usage": 11.2,
-				"cpu_overheating": false,
-				"cpu_temp": 53.0,
-				"software_start": "2023-12-01T16:11:06.092Z",
-				"software_uptime": 0.0241,
-				"ssd_smart_data": {
-					"test_passed": true,
-					"critical_warning": "0x00",
-					"temp": 34,
-					"available_spare": 100,
-					"available_spare_threshold": 10,
-					"percentage_used": 1,
-					"unsafe_shutdowns": 70,
-					"integrity_errors": 0
-				}
-			},
-			"software": {
-				"system_platform": "Linux-5.4.0-167-generic-x86_64-with-glibc2.29",
-				"python_version": "3.8.10",
-				"scos_sensor_version": "sea-prototype-v0.4.2-4-gbc10e57",
-				"scos_actions_version": "6.4.2",
-				"scos_sigan_plugin": {
-					"name": "scos_tekrsa",
-					"version": "3.1.5"
-				},
-				"preselector_api_version": "3.1.0"
-			}
-			
-		},
+    "ntia-diagnostics:diagnostics" : {
+      "computer" : {
+        "cpu_max_clock" : 4800.0,
+        "cpu_min_clock" : 1120.0,
+        "cpu_mean_clock" : 3100.0,
+        "action_cpu_usage" : 44.3,
+        "system_load_5m" : 24.62,
+        "memory_usage" : 23.8,
+        "cpu_temp" : 67.0,
+        "cpu_overheating" : false,
+        "cpu_uptime" : 10.0,
+        "software_uptime" : 1.0,
+        "software_start" : "2024-01-02T19:16:50.514Z",
+        "ntp_active" : true,
+        "ntp_sync" : true,
+        "ssd_smart_data" : {
+          "temp" : 41.0,
+          "test_passed" : true,
+          "critical_warning" : "0x00",
+          "available_spare" : 100.0,
+          "available_spare_threshold" : 10.0,
+          "percentage_used" : 1.0,
+          "unsafe_shutdowns" : 18,
+          "integrity_errors" : 0
+        },
+        "action_runtime" : 100.0
+      },
+      "datetime" : "2024-01-02T19:16:50.509Z",
+      "preselector" : {
+        "temp" : 20.0,
+        "humidity" : 65.0,
+        "noise_diode_temp" : 21.8,
+        "lna_temp" : 22.5,
+        "door_closed" : true,
+        "noise_diode_path_enabled" : false,
+        "antenna_path_enabled" : true,
+        "noise_diode_powered" : false,
+        "lna_powered" : true
+      },
+      "software" : {
+        "system_platform" : "Linux-9.9.9-example-platform",
+        "python_version" : "3.11.5",
+        "scos_sensor_version" : "1.0.0-gcbb75ad",
+        "scos_actions_version" : "2.0.0",
+        "scos_sigan_plugin" : {
+          "name" : "scos_tekrsa",
+          "version" : "3.1.4"
+        },
+        "preselector_api_version" : "1.0.0",
+        "sigan_firmware_version" : "1.2.3",
+        "sigan_api_version" : "V1.0.0"
+      },
+      "spu" : {
+        "cooling" : false,
+        "heating" : false,
+        "low_battery" : false,
+        "battery_backup" : false,
+        "preselector_powered" : true,
+        "sigan_powered" : true,
+        "door_closed" : true,
+        "humidity_sensors" : [ {
+          "name" : "internal_humidity",
+          "value" : 17.0
+        } ],
+        "temperature_sensors" : [ {
+          "name" : "internal_temp",
+          "value" : 32.0
+        } ],
+        "power_sensors" : [ {
+          "name" : "5V_power_monitor",
+          "value" : 5.0,
+          "expected_value" : 5.0
+        } ],
+        "ups_healthy" : true,
+        "replace_battery" : false
+      }
+    }
   },
   ...
   "captures" : [ ... ],


### PR DESCRIPTION
- Adds two optional metadata fields to the `Software` metadata object:
  - `sigan_api_version` to record the signal analyzer API version (distinct from the `scos_sigan_plugin` version)
  - `sigan_firmware_version` to record the firmware version of the signal analyzer
- Adds the `lna_powered` field of the preselector diagnostics object to the markdown spec document. This field was supported since 2.0.0, but was missing from the markdown.
- Updates the `ntia-diagnostics` example JSON generator and JSON example in the markdown spec
- Bumps package version to 3.1.0