### PR TITLE
SEA-187 Add disk usage field to `Computer` diagnostics metadata object

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -14,7 +14,7 @@ def versions = [
 def archiveBaseName= 'sigmf-ns-ntia'
 
 group = 'gov.doc.ntia'
-version = '3.1.0'
+version = '3.2.0'
 
 
 repositories {

--- a/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/examples/ext/DiagnosticsExample.java
@@ -18,7 +18,7 @@ public class DiagnosticsExample implements Example {
   public static Extension getExtension() {
     Extension extension = new Extension();
     extension.setName("ntia-diagnostics");
-    extension.setVersion("v2.1.0");
+    extension.setVersion("v2.2.0");
     extension.setOptional(false);
     return extension;
   }
@@ -127,6 +127,7 @@ public class DiagnosticsExample implements Example {
     computer.setSoftwareStart(ExampleUtils.getDatetimeNow());
     computer.setNtpActive(true);
     computer.setNtpSync(true);
+    computer.setDiskUsage(25.0);
     computer.setActionRuntime(100.0);
     return computer;
   }

--- a/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Computer.java
+++ b/java/src/main/java/gov/doc/ntia/sigmf/ext/diagnostics/Computer.java
@@ -49,6 +49,9 @@ public class Computer {
   @JsonProperty(value = "ntp_sync")
   protected Boolean ntpSync;
 
+  @JsonProperty(value = "disk_usage")
+  protected Double diskUsage;
+
   @Valid
   @JsonProperty(value = "ssd_smart_data")
   private SsdSmartData smartData;
@@ -166,6 +169,14 @@ public class Computer {
 
   public void setNtpSync(Boolean ntpSync) {
     this.ntpSync = ntpSync;
+  }
+
+  public Double getDiskUsage() {
+    return diskUsage;
+  }
+
+  public void setDiskUsage(Double diskUsage) {
+    this.diskUsage = diskUsage;
   }
 
   public Double getActionRuntime() {

--- a/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
+++ b/java/src/test/java/gov/doc/ntia/sigmf/ext/global/sensor/NasctnSensorTest.java
@@ -69,18 +69,6 @@ public class NasctnSensorTest {
   }
 
   @Test
-  public void testDeserializeActionRuntime() {
-    Assertions.assertEquals(94.88, metaDoc.getGlobal().getDiagnostics().getComputer().getActionRuntime().doubleValue());
-  }
-
-  @Test
-  public void testSerializeDeserializeActionRuntime() {
-    Assertions.assertEquals(
-            94.88,
-        metaDocFromString.getGlobal().getDiagnostics().getComputer().getActionRuntime().doubleValue());
-  }
-
-  @Test
   public void testDeserializeDataProducts() {
     List<AbstractDataProduct> dataProducts = metaDoc.getGlobal().getDataProducts();
     Assertions.assertEquals(4, dataProducts.size());
@@ -181,6 +169,10 @@ public class NasctnSensorTest {
     Assertions.assertEquals(1.0, computer.getSmartData().getPercentageUsed().doubleValue());
     Assertions.assertEquals(70, computer.getSmartData().getUnsafeShutdowns().intValue());
     Assertions.assertEquals(0, computer.getSmartData().getIntegrityErrors().intValue());
+    Assertions.assertEquals(5.0, computer.getDiskUsage().doubleValue());
+    Assertions.assertEquals(94.88, computer.getActionRuntime().doubleValue());
+    Assertions.assertEquals(true, computer.getNtpSync());
+    Assertions.assertEquals(true, computer.getNtpActive());
   }
 
   @Test
@@ -207,6 +199,10 @@ public class NasctnSensorTest {
     Assertions.assertEquals(1.0, computer.getSmartData().getPercentageUsed().doubleValue());
     Assertions.assertEquals(70, computer.getSmartData().getUnsafeShutdowns().intValue());
     Assertions.assertEquals(0, computer.getSmartData().getIntegrityErrors().intValue());
+    Assertions.assertEquals(5.0, computer.getDiskUsage().doubleValue());
+    Assertions.assertEquals(94.88, computer.getActionRuntime().doubleValue());
+    Assertions.assertEquals(true, computer.getNtpSync());
+    Assertions.assertEquals(true, computer.getNtpActive());
   }
 
   @Test

--- a/java/src/test/resources/meta.sigmf-meta
+++ b/java/src/test/resources/meta.sigmf-meta
@@ -14,7 +14,7 @@
       },
       {
         "name": "ntia-diagnostics",
-        "version": "v2.1.0",
+        "version": "v2.2.0",
         "optional": true
       },
       {
@@ -374,7 +374,10 @@
           "percentage_used": 1,
           "unsafe_shutdowns": 70,
           "integrity_errors": 0
-        }
+        },
+        "ntp_sync": true,
+        "ntp_active": true,
+        "disk_usage": 5.0
       },
       "software": {
         "system_platform": "Linux-5.4.0-167-generic-x86_64-with-glibc2.29",

--- a/java/src/test/resources/sigmf-ns-ntia.schema
+++ b/java/src/test/resources/sigmf-ns-ntia.schema
@@ -868,7 +868,10 @@
 				},
 			    "action_runtime": {
                     "type": "number"
-                }
+                },
+				"disk_usage": {
+					"type": "number"
+				}
 			},
 			"additionalProperties": false
 		},

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -1,4 +1,4 @@
-# The `ntia-diagnostics` SigMF Extension Namespace v2.1.0
+# The `ntia-diagnostics` SigMF Extension Namespace v2.2.0
 
 This document defines the `ntia-diagnostics` extension namespace for the Signal Metadata Format (SigMF) specification. This extension namespace provides metadata to describe system diagnostic information.
 
@@ -47,7 +47,6 @@ The `Preselector` diagnostics object has the following properties:
 | `antenna_path_enabled`     | false    | boolean | N/A            | Boolean indicating whether the antenna path is enabled.         |
 | `noise_diode_path_enabled` | false    | boolean | N/A            | Boolean indicating whether the noise diode path is enabled.     |
 
-
 ### 0.3 The `SPU` Diagnostics Object
 
 The `SPU` diagnostics object has the following properties:
@@ -68,31 +67,28 @@ The `SPU` diagnostics object has the following properties:
 | `replace_battery`             | false    | boolean                                                   | N/A            | Boolean indicating True if the battery backup needs to be replaced |
 | `ups_healthy`                 | false    | boolean                                                   | N/A            | Boolean indicating false if the UPS has a failure                  |
 
-
-
-
 ### 0.4 The `Computer` Diagnostics Object
 
 The `Computer` diagnostics object has the following properties:
 
-| name               | required   | type                                                    | unit                 | description                                                                                              |
-|--------------------|------------|---------------------------------------------------------|----------------------|----------------------------------------------------------------------------------------------------------|
-| `cpu_min_clock`    | false      | double                                                  | MHz                  | Minimum sampled clock speed.                                                                             |
-| `cpu_max_clock`    | false      | double                                                  | MHz                  | Maximum sampled clock speed.                                                                             |
-| `cpu_mean_clock`   | false      | double                                                  | MHz                  | Mean sampled clock speed.                                                                                |
-| `cpu_uptime`       | false      | double                                                  | days                 | Number of days since the computer started                                                                |
-| `action_cpu_usage` | false      | double                                                  | percent              | CPU utilization during action execution.                                                                 |
-|  `action_runtime`  | false      | double                                                  | seconds              | Total action execution time.                                                                             |
-| `system_load_5m`   | false      | double                                                  | percent              | Number of processes in a runnable state over the previous 5 minutes as a percent of the number of CPUs.  |
-| `memory_usage`     | false      | double                                                  | percent              | Average percent of memory used during action execution.                                                  |
-| `cpu_overheating`  | false      | boolean                                                 | N/A                  | True if the CPU is overheating.                                                                          |
-| `cpu_temp`         | false      | double                                                  | degree Celsius       | CPU temperature.                                                                                         |
-| `software_start`   | false      | string                                                  | ISO-8601 (see above) | The time at which the sensor software started.                                                           |
-| `software_uptime`  | false      | double                                                  | days                 | Number of days since the sensor software started.                                                        |
-| `ssd_smart_data`   | false      | [SsdSmartData](#05-the-ssdsmartdata-diagnostics-object) | N/A                  | Information provided by the drive Self-Monitoring, Analysis, and Reporting Technology.                   |
-| `ntp_active`       | false      | boolean                                                 | N/A                  | True if NTP service is active on the computer                                                            |
-| `ntp_sync`         | false      | boolean                                                 | N/A                  | True if the system clock is synchronized with NTP                                                        |
-
+| name               | required | type                                                    | unit                 | description                                                                                             |
+|--------------------|----------|---------------------------------------------------------|----------------------|---------------------------------------------------------------------------------------------------------|
+| `cpu_min_clock`    | false    | double                                                  | MHz                  | Minimum sampled clock speed.                                                                            |
+| `cpu_max_clock`    | false    | double                                                  | MHz                  | Maximum sampled clock speed.                                                                            |
+| `cpu_mean_clock`   | false    | double                                                  | MHz                  | Mean sampled clock speed.                                                                               |
+| `cpu_uptime`       | false    | double                                                  | days                 | Number of days since the computer started                                                               |
+| `action_cpu_usage` | false    | double                                                  | percent              | CPU utilization during action execution.                                                                |
+| `action_runtime`   | false    | double                                                  | seconds              | Total action execution time.                                                                            |
+| `system_load_5m`   | false    | double                                                  | percent              | Number of processes in a runnable state over the previous 5 minutes as a percent of the number of CPUs. |
+| `memory_usage`     | false    | double                                                  | percent              | Average percent of memory used during action execution.                                                 |
+| `cpu_overheating`  | false    | boolean                                                 | N/A                  | True if the CPU is overheating.                                                                         |
+| `cpu_temp`         | false    | double                                                  | degree Celsius       | CPU temperature.                                                                                        |
+| `software_start`   | false    | string                                                  | ISO-8601 (see above) | The time at which the sensor software started.                                                          |
+| `software_uptime`  | false    | double                                                  | days                 | Number of days since the sensor software started.                                                       |
+| `ssd_smart_data`   | false    | [SsdSmartData](#05-the-ssdsmartdata-diagnostics-object) | N/A                  | Information provided by the drive Self-Monitoring, Analysis, and Reporting Technology.                  |
+| `ntp_active`       | false    | boolean                                                 | N/A                  | True if NTP service is active on the computer                                                           |
+| `ntp_sync`         | false    | boolean                                                 | N/A                  | True if the system clock is synchronized with NTP                                                       |
+| `disk_usage`       | false    | double                                                  | percent              | Percentage of total disk usage on the computer                                                          |
 
 ### 0.5 The `SsdSmartData` Diagnostics Object
 
@@ -126,7 +122,7 @@ The `Software` versions object has the following properties:
 
 ### 0.7 The SCOS Plugin Object
 
-The ``ScosPlugin`` object has the following properties: 
+The ``ScosPlugin`` object has the following properties:
 
 | name      | required | type   | description                                                  |
 |-----------|----------|--------|--------------------------------------------------------------|
@@ -135,7 +131,7 @@ The ``ScosPlugin`` object has the following properties:
 
 ### 0.8 The Diagnostic Sensor Object
 
-The ``DiagnosticSensor`` object has the following properties: 
+The ``DiagnosticSensor`` object has the following properties:
 
 | name              | required | type   | description                                                             |
 |-------------------|----------|--------|-------------------------------------------------------------------------|
@@ -145,10 +141,6 @@ The ``DiagnosticSensor`` object has the following properties:
 | `maximum_allowed` | false    | double | The maximum value allowed from the sensor before action should be taken |
 | `minimum_allowed` | false    | double | The minimum value allowed from the sensor before action should be taken |
 | `value`           | true     | double | The value provided by the sensor                                        |
-
-
-
-
 
 ## 1 Global
 

--- a/ntia-diagnostics.sigmf-ext.md
+++ b/ntia-diagnostics.sigmf-ext.md
@@ -177,13 +177,12 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
       "optional" : false
     }, {
       "name" : "ntia-diagnostics",
-      "version" : "v2.1.0",
+      "version" : "v2.2.0",
       "optional" : false
     } ],
     "ntia-core:classification" : "UNCLASSIFIED",
     "ntia-diagnostics:diagnostics" : {
       "computer" : {
-        "action_runtime" : 100.0,
         "cpu_max_clock" : 4800.0,
         "cpu_min_clock" : 1120.0,
         "cpu_mean_clock" : 3100.0,
@@ -194,21 +193,23 @@ The `ntia-diagnostics` extension does not extend the `collection` SigMF object.
         "cpu_overheating" : false,
         "cpu_uptime" : 10.0,
         "software_uptime" : 1.0,
-        "software_start" : "2024-01-02T19:16:50.514Z",
+        "software_start" : "2024-03-02T00:04:45.204Z",
         "ntp_active" : true,
         "ntp_sync" : true,
+        "disk_usage" : 25.0,
         "ssd_smart_data" : {
-          "temp": 41.0,
-          "test_passed": true,
-          "critical_warning": "0x00",
-          "available_spare": 100.0,
-          "available_spare_threshold": 10.0,
-          "percentage_used": 1.0,
-          "unsafe_shutdowns": 18,
-          "integrity_errors": 0
-        }
+          "temp" : 41.0,
+          "test_passed" : true,
+          "critical_warning" : "0x00",
+          "available_spare" : 100.0,
+          "available_spare_threshold" : 10.0,
+          "percentage_used" : 1.0,
+          "unsafe_shutdowns" : 18,
+          "integrity_errors" : 0
+        },
+        "action_runtime" : 100.0
       },
-      "datetime" : "2024-01-02T19:16:50.509Z",
+      "datetime" : "2024-03-02T00:04:45.191Z",
       "preselector" : {
         "temp" : 20.0,
         "humidity" : 65.0,


### PR DESCRIPTION
Also adds some missing tests for NTP-related fields.